### PR TITLE
EscalateDirective causes a nil pointer deference when applied to root actor

### DIFF
--- a/actor/context.go
+++ b/actor/context.go
@@ -283,6 +283,11 @@ func (cell *actorCell) handleFailure(msg *Failure) {
 }
 
 func (cell *actorCell) EscalateFailure(who *PID, reason interface{}) {
+	if cell.Parent() == nil {
+		log.Printf("[ACTOR] '%v' Cannot escalate failure from root actor; stopping instead", cell.debugString())
+		cell.Self().sendSystemMessage(stopMessage)
+		return
+	}
 	//suspend self
 	cell.Self().sendSystemMessage(suspendMailboxMessage)
 	//send failure to parent
@@ -427,7 +432,7 @@ func (cell *actorCell) BecomeStacked(behavior Receive) {
 
 func (cell *actorCell) UnbecomeStacked() {
 	if cell.behavior.Len() == 0 {
-		panic("Can not unbecome actor base behavior")
+		panic("Cannot unbecome actor base behavior")
 	}
 	cell.receive, _ = cell.behavior.Pop()
 }

--- a/examples/supervision/main.go
+++ b/examples/supervision/main.go
@@ -30,11 +30,11 @@ func (state *childActor) Receive(context actor.Context) {
 	case *actor.Started:
 		fmt.Println("Starting, initialize actor here")
 	case *actor.Stopping:
-		fmt.Println("Stopping, actor is about shut down")
+		fmt.Println("Stopping, actor is about to shut down")
 	case *actor.Stopped:
-		fmt.Println("Stopped, actor and it's children are stopped")
+		fmt.Println("Stopped, actor and its children are stopped")
 	case *actor.Restarting:
-		fmt.Println("Restarting, actor is about restart")
+		fmt.Println("Restarting, actor is about to restart")
 	case *hello:
 		fmt.Printf("Hello %v\n", msg.Who)
 		panic("Ouch")


### PR DESCRIPTION
If the supervision strategy for a root-level actor returns EscalateDirective, the program would crash. Instead, the actor should be stopped without bringing down the other actors in the program.