### PR TITLE
Remove sharp character on protobuf building and add missing get commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,18 @@ go get github.com/gogo/protobuf/protoc-gen-gogo
 go get github.com/gogo/protobuf/gogoproto
 go get github.com/gogo/protobuf/protoc-gen-gofast
 go get google.golang.org/grpc
-#go get github.com/gogo/protobuf/protoc-gen-gogofast
-#go get github.com/gogo/protobuf/protoc-gen-gogofaster
-#go get github.com/gogo/protobuf/protoc-gen-gogoslick
+go get github.com/gogo/protobuf/protoc-gen-gogofast
+go get github.com/gogo/protobuf/protoc-gen-gogofaster
+go get github.com/gogo/protobuf/protoc-gen-gogoslick
+go get github.com/Workiva/go-datastructures/queue
+go get github.com/emirpasic/gods/stacks/linkedliststack
+go get github.com/orcaman/concurrent-map
+go get github.com/AsynkronIT/gonet
+go get github.com/hashicorp/consul/api
+go get github.com/AsynkronIT/goconsole
+go get github.com/emirpasic/gods/sets/hashset
+go get github.com/serialx/hashring
+go get github.com/couchbase/gocb
 ```
 
 Finally, run the `make` tool in the package's root to generate the protobuf definitions and build the packages.


### PR DESCRIPTION

1. Some sharp characters was in the beginning of some lines to get protobuf packages.
2. Adding of missing get commands for the protoactor-go dependencies.