### PR TITLE
Partitioned PID Cache Actors

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -19,6 +19,7 @@ func Start(clusterName, address string, provider ClusterProvider) {
 		kindPIDMap[kind] = kindPID
 	}
 	subscribePartitionKindsToEventStream()
+	spawnPidCacheActor()
 	spawnMembershipActor()
 	subscribeMembershipActorToEventStream()
 	provider.RegisterMember(clusterName, h, p, kinds)

--- a/cluster/registry.go
+++ b/cluster/registry.go
@@ -1,10 +1,9 @@
 package cluster
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
-
-	"os"
 
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/remote"
@@ -20,34 +19,19 @@ func getRandomActivator(kind string) string {
 
 //Get a PID to a virtual actor
 func Get(name string, kind string) (*actor.PID, error) {
-	pid := cache.Get(name)
-	if pid == nil {
 
-		address := getNode(name, kind)
-		remotePID := partitionForKind(address, kind)
-
-		//request the pid of the "id" from the correct partition
-		req := &remote.ActorPidRequest{
-			Name: name,
-			Kind: kind,
-		}
-
-		//await the response
-		res, err := remotePID.RequestFuture(req, 5*time.Second).Result()
-		if err != nil {
-			logerr.Printf("ActorPidRequest for '%v' timed out, failure %v", name, err)
-			return nil, err
-		}
-
-		//unwrap the result
-		typed, ok := res.(*remote.ActorPidResponse)
-		if !ok {
-			logerr.Printf("ActorPidRequest for '%v' returned incorrect response, expected ActorPidResponse", name)
-			os.Exit(1)
-		}
-		pid = typed.Pid
-		cache.Add(name, pid)
-		return pid, nil
+	req := &pidCacheRequest{
+		kind: kind,
+		name: name,
 	}
-	return pid, nil
+
+	res, err := pidCacheActorPid.RequestFuture(req, 5*time.Second).Result()
+	if err != nil {
+		return nil, err
+	}
+	typed, ok := res.(*remote.ActorPidResponse)
+	if !ok {
+		return nil, fmt.Errorf("Hej hopp")
+	}
+	return typed.Pid, nil
 }

--- a/remote/remote_process.go
+++ b/remote/remote_process.go
@@ -27,7 +27,7 @@ func sendRemoteMessage(pid *actor.PID, message interface{}, sender *actor.PID) {
 		envelope, _ := serialize(msg, pid, sender)
 		endpointManagerPID.Tell(envelope)
 	default:
-		logerr.Printf("failed, trying to send non Proto %s message to %v", reflect.TypeOf(msg), pid)
+		logerr.Printf("failed, trying to send non Proto %s message to %v from %v", reflect.TypeOf(msg), pid, sender)
 	}
 }
 


### PR DESCRIPTION
This PR introduces a new way to resolve cached cluster PID's.
Instead of having a global map of name -> PID.
We now hide all this inside a dedicated actor for this.
We also run this actor in multiple instances behind a consistent has pool.
This means that reading and writing to the cache will have less contention as we can have as many partitions as we'd like.