### PR TITLE
Fix unused assignment

### DIFF
--- a/remote/activator_actor.go
+++ b/remote/activator_actor.go
@@ -87,7 +87,7 @@ func (*activator) Receive(context actor.Context) {
 			name = actor.ProcessRegistry.NextId()
 		}
 
-		pid, _ := actor.SpawnNamed(&props, "Remote$"+msg.Name)
+		pid, _ := actor.SpawnNamed(&props, "Remote$"+name)
 		response := &ActorPidResponse{
 			Pid: pid,
 		}


### PR DESCRIPTION
Fix unused assignment

* Initially, you creating variable `name` and assigning to her value of `msg.Name` and checks for an empty name. 
* But in the end `msg.Name` using to create an actor `actor.SpawnNamed(&props, "Remote$"+msg.Name)` where it make sense to use `name`