### PR TITLE
Separated dispatcher from the mailbox

### DIFF
--- a/mailbox/dispatcher.go
+++ b/mailbox/dispatcher.go
@@ -1,20 +1,45 @@
 package mailbox
 
+import "runtime"
+
 type Dispatcher interface {
 	Schedule(fn func())
 	Throughput() int
+	AfterStart()
+	BeforeTerminate()
+	BeforeBatchProcess()
+	BeforeProcessingMessage()
 }
 
-type goroutineDispatcher int
+type goroutineDispatcher struct {
+	throughput int
+	index      int
+}
 
 func (goroutineDispatcher) Schedule(fn func()) {
 	go fn()
 }
 
+func (d goroutineDispatcher) AfterStart() {
+}
+func (d goroutineDispatcher) BeforeTerminate() {
+}
 func (d goroutineDispatcher) Throughput() int {
-	return int(d)
+	return d.throughput
+}
+
+func (d goroutineDispatcher) BeforeProcessingMessage() {
+	if d.index > d.throughput {
+		d.index = 0
+		runtime.Gosched()
+	}
+	d.index++
+}
+
+func (d goroutineDispatcher) BeforeBatchProcess() {
+	d.index = 0
 }
 
 func NewDefaultDispatcher(throughput int) Dispatcher {
-	return goroutineDispatcher(throughput)
+	return &goroutineDispatcher{throughput: throughput}
 }


### PR DESCRIPTION
Moved checking throughput and yielding functionalities to dispatcher
code. This helps with separation of concepts and provide a cleaner
way to add new dispatchers. Functions such as `AfterStart` and
`BeforeTermiante` were added to improve the functionality further. 
This can add a bit of overhead. 