### PR TITLE
Middleware refactoring

### DIFF
--- a/actor/future_test.go
+++ b/actor/future_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestFuture_PipeTo_Message(t *testing.T) {
@@ -33,7 +32,9 @@ func TestFuture_PipeTo_Message(t *testing.T) {
 	fp, _ := ref.(*futureProcess)
 
 	fp.SendUserMessage(f.pid, "hello", nil)
-	mock.AssertExpectationsForObjects(t, p1, p2, p3)
+	p1.AssertExpectations(t)
+	p2.AssertExpectations(t)
+	p3.AssertExpectations(t)
 	assert.Empty(t, fp.pipes, "pipes were not cleared")
 }
 
@@ -64,7 +65,9 @@ func TestFuture_PipeTo_TimeoutSendsError(t *testing.T) {
 	assert.IsType(t, &futureProcess{}, ref)
 	fp, _ := ref.(*futureProcess)
 
-	mock.AssertExpectationsForObjects(t, p1, p2, p3)
+	p1.AssertExpectations(t)
+	p2.AssertExpectations(t)
+	p3.AssertExpectations(t)
 	assert.Empty(t, fp.pipes, "pipes were not cleared")
 }
 

--- a/actor/local_context.go
+++ b/actor/local_context.go
@@ -14,7 +14,7 @@ type localContext struct {
 	actor              Actor
 	supervisor         SupervisorStrategy
 	producer           Producer
-	middleware         ActorFunc
+	inboundMiddleware  ActorFunc
 	outboundMiddleware SenderFunc
 	behavior           behaviorStack
 	receive            ActorFunc
@@ -29,16 +29,29 @@ type localContext struct {
 	restartStats       *RestartStatistics
 }
 
-func newLocalContext(producer Producer, supervisor SupervisorStrategy, middleware ActorFunc, middleware2 SenderFunc, parent *PID) *localContext {
-	cell := &localContext{
-		parent:             parent,
-		producer:           producer,
-		supervisor:         supervisor,
-		middleware:         middleware,
-		outboundMiddleware: middleware2,
+func newLocalContext(producer Producer, supervisor SupervisorStrategy, inboundMiddleware []InboundMiddleware, outboundMiddleware []OutboundMiddleware, parent *PID) *localContext {
+	this := &localContext{
+		parent:     parent,
+		producer:   producer,
+		supervisor: supervisor,
 	}
-	cell.incarnateActor()
-	return cell
+
+	// Construct the inbound middleware chain with the final receiver at the end
+	this.inboundMiddleware = makeInboundMiddlewareChain(inboundMiddleware, func(ctx Context) {
+		if _, ok := this.message.(*PoisonPill); ok {
+			this.self.Stop()
+		} else {
+			this.receive(ctx)
+		}
+	})
+
+	// Construct the outbound middleware chain with the final sender at the end
+	this.outboundMiddleware = makeOutboundMiddlewareChain(outboundMiddleware, func(_ Context, target *PID, envelope MessageEnvelope) {
+		target.ref().SendUserMessage(target, envelope.Message, envelope.Sender)
+	})
+
+	this.incarnateActor()
+	return this
 }
 
 func (ctx *localContext) Actor() Actor {
@@ -214,25 +227,11 @@ func (ctx *localContext) InvokeUserMessage(md interface{}) {
 	}
 }
 
-// localContextReceiver is used when middleware chain is required
-func localContextReceiver(ctx Context) {
-	a := ctx.(*localContext)
-	if _, ok := a.message.(*PoisonPill); ok {
-		a.self.Stop()
-	} else {
-		a.receive(ctx)
-	}
-}
-
-func localContextSender(_ Context, target *PID, envelope MessageEnvelope) {
-	target.ref().SendUserMessage(target, envelope.Message, envelope.Sender)
-}
-
 func (ctx *localContext) processMessage(m interface{}) {
 	ctx.message = m
 
-	if ctx.middleware != nil {
-		ctx.middleware(ctx)
+	if ctx.inboundMiddleware != nil {
+		ctx.inboundMiddleware(ctx)
 	} else {
 		if _, ok := m.(*PoisonPill); ok {
 			ctx.self.Stop()

--- a/actor/local_context.go
+++ b/actor/local_context.go
@@ -37,13 +37,15 @@ func newLocalContext(producer Producer, supervisor SupervisorStrategy, inboundMi
 	}
 
 	// Construct the inbound middleware chain with the final receiver at the end
-	this.inboundMiddleware = makeInboundMiddlewareChain(inboundMiddleware, func(ctx Context) {
-		if _, ok := this.message.(*PoisonPill); ok {
-			this.self.Stop()
-		} else {
-			this.receive(ctx)
-		}
-	})
+	if inboundMiddleware != nil {
+		this.inboundMiddleware = makeInboundMiddlewareChain(inboundMiddleware, func(ctx Context) {
+			if _, ok := this.message.(*PoisonPill); ok {
+				this.self.Stop()
+			} else {
+				this.receive(ctx)
+			}
+		})
+	}
 
 	// Construct the outbound middleware chain with the final sender at the end
 	this.outboundMiddleware = makeOutboundMiddlewareChain(outboundMiddleware, func(_ Context, target *PID, envelope MessageEnvelope) {

--- a/actor/local_context_test.go
+++ b/actor/local_context_test.go
@@ -111,6 +111,40 @@ func BenchmarkLocalContext_ProcessMessageWithMiddleware(b *testing.B) {
 	}
 }
 
+func benchmarkLocalContext_SpawnWithMiddlewareN(n int, b *testing.B) {
+	middlwareFn := func(next ActorFunc) ActorFunc {
+		return func(context Context) {
+			next(context)
+		}
+	}
+
+	props := FromProducer(nullProducer)
+	for i := 0; i < n; i++ {
+		props = props.WithMiddleware(middlwareFn)
+	}
+
+	parent := &localContext{self: NewLocalPID("foo")}
+	for i := 0; i < b.N; i++ {
+		parent.Spawn(props)
+	}
+}
+
+func BenchmarkLocalContext_SpawnWithMiddleware0(b *testing.B) {
+	benchmarkLocalContext_SpawnWithMiddlewareN(0, b)
+}
+
+func BenchmarkLocalContext_SpawnWithMiddleware1(b *testing.B) {
+	benchmarkLocalContext_SpawnWithMiddlewareN(1, b)
+}
+
+func BenchmarkLocalContext_SpawnWithMiddleware2(b *testing.B) {
+	benchmarkLocalContext_SpawnWithMiddlewareN(2, b)
+}
+
+func BenchmarkLocalContext_SpawnWithMiddleware5(b *testing.B) {
+	benchmarkLocalContext_SpawnWithMiddlewareN(5, b)
+}
+
 func TestActorContinueFutureInActor(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/actor/local_context_test.go
+++ b/actor/local_context_test.go
@@ -23,7 +23,7 @@ func TestLocalContext_SpawnNamed(t *testing.T) {
 
 	parent := &localContext{self: NewLocalPID("foo")}
 	parent.SpawnNamed(props, "bar")
-	mock.AssertExpectationsForObjects(t, p)
+	p.AssertExpectations(t)
 }
 
 // TestLocalContext_Stop verifies if context is stopping and receives a Watch message, it should
@@ -42,7 +42,8 @@ func TestLocalContext_Stop(t *testing.T) {
 	lc.InvokeSystemMessage(&Stop{})
 	lc.InvokeSystemMessage(&Watch{Watcher: other})
 
-	mock.AssertExpectationsForObjects(t, p, o)
+	p.AssertExpectations(t)
+	o.AssertExpectations(t)
 }
 
 func TestLocalContext_SendMessage_WithOutboundMiddleware(t *testing.T) {

--- a/actor/middleware_chain.go
+++ b/actor/middleware_chain.go
@@ -1,23 +1,23 @@
 package actor
 
-func makeMiddlewareChain(middleware []func(ActorFunc) ActorFunc, actorReceiver ActorFunc) ActorFunc {
+func makeInboundMiddlewareChain(middleware []InboundMiddleware, lastReceiver ActorFunc) ActorFunc {
 	if len(middleware) == 0 {
 		return nil
 	}
 
-	h := middleware[len(middleware)-1](actorReceiver)
+	h := middleware[len(middleware)-1](lastReceiver)
 	for i := len(middleware) - 2; i >= 0; i-- {
 		h = middleware[i](h)
 	}
 	return h
 }
 
-func makeOutboundMiddlewareChain(outboundMiddleware []func(SenderFunc) SenderFunc, actorReceiver SenderFunc) SenderFunc {
+func makeOutboundMiddlewareChain(outboundMiddleware []OutboundMiddleware, lastSender SenderFunc) SenderFunc {
 	if len(outboundMiddleware) == 0 {
 		return nil
 	}
 
-	h := outboundMiddleware[len(outboundMiddleware)-1](actorReceiver)
+	h := outboundMiddleware[len(outboundMiddleware)-1](lastSender)
 	for i := len(outboundMiddleware) - 2; i >= 0; i-- {
 		h = outboundMiddleware[i](h)
 	}

--- a/actor/middleware_chain_test.go
+++ b/actor/middleware_chain_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func middleware(called *int) func(ActorFunc) ActorFunc {
+func middleware(called *int) InboundMiddleware {
 	return func(next ActorFunc) ActorFunc {
 		fn := func(context Context) {
 			*called = context.Message().(int)
@@ -18,10 +18,10 @@ func middleware(called *int) func(ActorFunc) ActorFunc {
 	}
 }
 
-func TestMakeReceiverMiddleware_CallsInCorrectOrder(t *testing.T) {
+func TestMakeInboundMiddleware_CallsInCorrectOrder(t *testing.T) {
 	var c [3]int
 
-	r := []func(ActorFunc) ActorFunc{
+	r := []InboundMiddleware{
 		middleware(&c[0]),
 		middleware(&c[1]),
 		middleware(&c[2]),
@@ -32,7 +32,7 @@ func TestMakeReceiverMiddleware_CallsInCorrectOrder(t *testing.T) {
 	mc.On("Message").Return(2).Once()
 	mc.On("Message").Return(3).Once()
 
-	chain := makeMiddlewareChain(r, func(_ Context) {})
+	chain := makeInboundMiddlewareChain(r, func(_ Context) {})
 	chain(mc)
 
 	assert.Equal(t, 1, c[0])
@@ -41,6 +41,6 @@ func TestMakeReceiverMiddleware_CallsInCorrectOrder(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, mc)
 }
 
-func TestMakeReceiverMiddleware_ReturnsNil(t *testing.T) {
-	assert.Nil(t, makeMiddlewareChain([]func(ActorFunc) ActorFunc{}, func(_ Context) {}))
+func TestMakeInboundMiddleware_ReturnsNil(t *testing.T) {
+	assert.Nil(t, makeInboundMiddlewareChain([]InboundMiddleware{}, func(_ Context) {}))
 }

--- a/actor/middleware_chain_test.go
+++ b/actor/middleware_chain_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func middleware(called *int) InboundMiddleware {
@@ -38,7 +37,7 @@ func TestMakeInboundMiddleware_CallsInCorrectOrder(t *testing.T) {
 	assert.Equal(t, 1, c[0])
 	assert.Equal(t, 2, c[1])
 	assert.Equal(t, 3, c[2])
-	mock.AssertExpectationsForObjects(t, mc)
+	mc.AssertExpectations(t)
 }
 
 func TestMakeInboundMiddleware_ReturnsNil(t *testing.T) {

--- a/actor/spawn.go
+++ b/actor/spawn.go
@@ -37,7 +37,7 @@ func spawn(id string, props *Props, parent *PID) (*PID, error) {
 		return pid, ErrNameExists
 	}
 
-	cell := newLocalContext(props.actorProducer, props.getSupervisor(), props.middlewareChain, props.outboundMiddlewareChain, parent)
+	cell := newLocalContext(props.actorProducer, props.getSupervisor(), props.inboundMiddleware, props.outboundMiddleware, parent)
 	mb := props.produceMailbox(cell, props.getDispatcher())
 	lp.mailbox = mb
 	var ref Process = lp


### PR DESCRIPTION
This addresses the issue #105.

Inbound and outbound middleware chains are now built not in props, but at the moment of a local context creation. It allows capturing the local context in a closure and using it in a chain. The immediate benefit is that a context interface value can now be passed through the inbound middleware chain till the very end without asserting it to any particular type. Any middleware can now substitute the context value and pass it to the next element of the chain.

A few panicking tests have been fixed along the way.