### PR TITLE
Fix a bug in AwaitFuture

### DIFF
--- a/actor/local_context.go
+++ b/actor/local_context.go
@@ -434,12 +434,13 @@ func (ctx *localContext) AwaitFuture(f *Future, cont func(res interface{}, err e
 		cont(f.result, f.err)
 	}
 
+	message := ctx.message
 	//invoke the callback when the future completes
 	f.continueWith(func(res interface{}, err error) {
 		//send the wrapped callaback as a continuation message to self
 		ctx.self.sendSystemMessage(&continuation{
 			f:       wrapper,
-			message: ctx.message,
+			message: message,
 		})
 	})
 }


### PR DESCRIPTION
After the Receive function returns, ctx.message become nil.
So, the ctx.message have to be bound to a local variable.