### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,10 +329,9 @@ func (*MyActor) Receive(context actor.Context) {
 
 func main() {
     remote.Start("localhost:8091")
-    pid := actor.SpawnTemplate(&MyActor{})
 
     //register a name for our local actor so that it can be discovered remotely
-    actor.ProcessRegistry.Register("myactor", pid)
+	remote.Register("hello", actor.FromInstance(&MyActor{}))
     console.ReadLine()
 }
 ```

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ func main() {
     remote.Start("localhost:8091")
 
     //register a name for our local actor so that it can be discovered remotely
-	remote.Register("hello", actor.FromInstance(&MyActor{}))
+    remote.Register("hello", actor.FromInstance(&MyActor{}))
     console.ReadLine()
 }
 ```


### PR DESCRIPTION
I think the API changed for this one also

`actor.ProcessRegistry.Register("myactor", pid)` does not work anymore