### PR TITLE
Always send the original (possibly enveloped) message to router actor

### DIFF
--- a/router/process.go
+++ b/router/process.go
@@ -18,15 +18,17 @@ type process struct {
 }
 
 func (ref *process) SendUserMessage(pid *actor.PID, message interface{}) {
-
 	msg, sender := actor.UnwrapEnvelope(message)
-	if _, ok := message.(ManagementMessage); ok {
-		r, _ := actor.ProcessRegistry.Get(ref.router)
-		r.SendUserMessage(pid, msg)
-	} else {
+	if _, ok := msg.(ManagementMessage); !ok {
 		ref.state.RouteMessage(msg, sender)
+	} else {
+		r, _ := actor.ProcessRegistry.Get(ref.router)
+		// Always send the original message to the router actor,
+		// since if the message is enveloped, the sender need to get a response.
+		r.SendUserMessage(pid, message)
 	}
 }
+
 func (ref *process) SendSystemMessage(pid *actor.PID, message interface{}) {
 	switch msg := message.(type) {
 	case *actor.Watch:

--- a/router/process_test.go
+++ b/router/process_test.go
@@ -30,6 +30,7 @@ func TestRouterSendsUserMessageToChild(t *testing.T) {
 
 	routerPID := actor.Spawn(actor.FromSpawnFunc(spawner(grc)))
 	routerPID.Tell("hello")
+	routerPID.Request("hello", routerPID)
 
 	mock.AssertExpectationsForObjects(t, p, rs)
 }


### PR DESCRIPTION
Fixed issue #157.

BTW: I swapped the order of "if ... else ..." for better readability (I hope so).