### PR TITLE
Fix partition naming rule

### DIFF
--- a/cluster/partition_actor.go
+++ b/cluster/partition_actor.go
@@ -27,12 +27,12 @@ func subscribePartitionKindsToEventStream() {
 }
 
 func spawnPartitionActor(kind string) *actor.PID {
-	partitionPid, _ := actor.SpawnNamed(actor.FromProducer(newPartitionActor(kind)), "#partition-"+kind)
+	partitionPid, _ := actor.SpawnNamed(actor.FromProducer(newPartitionActor(kind)), "partition-"+kind)
 	return partitionPid
 }
 
 func partitionForKind(address, kind string) *actor.PID {
-	pid := actor.NewPID(address, "#partition-"+kind)
+	pid := actor.NewPID(address, "partition-"+kind)
 	return pid
 }
 


### PR DESCRIPTION
Old partition naming rule adds "#" prefix.
This is different with [protoactor-dotnet](https://github.com/AsynkronIT/protoactor-dotnet/blob/13bf29369764e8aa3716a5c3246467ab951794ea/src/Proto.Cluster/Partition.cs#L22), making them cannot talk to each other.