### PR TITLE
Replace HashRing method with Rendezvous

### DIFF
--- a/cluster/hashring.go
+++ b/cluster/hashring.go
@@ -1,51 +1,19 @@
 package cluster
 
 import (
-	"hash/fnv"
-	"math"
-
 	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/AsynkronIT/protoactor-go/cluster/rendezvous"
 	"github.com/AsynkronIT/protoactor-go/log"
 )
 
-const (
-	hashSize = uint32(math.MaxUint32)
-)
-
 func getNode(key, kind string) string {
-	v := hash(key)
+	//v := hash(key)
 	members := getMembers(kind)
 	if members == nil {
 		plog.Error("getNode: failed to get member", log.String("kind", kind))
 		return actor.ProcessRegistry.Address
 	}
 
-	bestV := hashSize
-	bestI := 0
-
-	//walk all members and find the node with the closest distance to the id hash
-	for i, n := range members {
-		h := hash(n)     //hash the node address
-		b := delta(h, v) //calculate the delta between key and node address
-		if b < bestV {
-			bestV = b
-			bestI = i
-		}
-	}
-
-	member := members[bestI]
-	return member
-}
-
-func delta(l uint32, r uint32) uint32 {
-	if l > r {
-		return l - r
-	}
-	return r - l
-}
-
-func hash(s string) uint32 {
-	h := fnv.New32a()
-	h.Write([]byte(s))
-	return h.Sum32()
+	rdv := rendezvous.New(members...)
+	return rdv.Get(key)
 }

--- a/cluster/partition_actor.go
+++ b/cluster/partition_actor.go
@@ -27,12 +27,12 @@ func subscribePartitionKindsToEventStream() {
 }
 
 func spawnPartitionActor(kind string) *actor.PID {
-	partitionPid, _ := actor.SpawnNamed(actor.FromProducer(newPartitionActor(kind)), "#partition-"+kind)
+	partitionPid, _ := actor.SpawnNamed(actor.FromProducer(newPartitionActor(kind)), "partition-"+kind)
 	return partitionPid
 }
 
 func partitionForKind(address, kind string) *actor.PID {
-	pid := actor.NewPID(address, "#partition-"+kind)
+	pid := actor.NewPID(address, "partition-"+kind)
 	return pid
 }
 

--- a/cluster/rendezvous/rendezvous.go
+++ b/cluster/rendezvous/rendezvous.go
@@ -1,0 +1,92 @@
+package rendezvous
+
+//Rendezvous.go
+//A FNV1A32 version of
+//https://github.com/tysonmote/rendezvous/blob/master/rendezvous.go
+
+import (
+	"hash"
+	"hash/fnv"
+	"sort"
+)
+
+type nodeScore struct {
+	node  []byte
+	score uint32
+}
+
+type byScore []nodeScore
+
+func (s byScore) Len() int           { return len(s) }
+func (s byScore) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s byScore) Less(i, j int) bool { return s[i].score < s[j].score }
+
+type Hash struct {
+	nodes  []nodeScore
+	hasher hash.Hash32
+}
+
+// New creates a new Hash with the given keys (optional).
+func New(nodes ...string) *Hash {
+	hash := &Hash{}
+	hash.hasher = fnv.New32a()
+	hash.Add(nodes...)
+	return hash
+}
+
+// Add takes any number of nodes and adds them to this Hash.
+func (h *Hash) Add(nodes ...string) {
+	for _, node := range nodes {
+		h.nodes = append(h.nodes, nodeScore{[]byte(node), 0})
+	}
+}
+
+// Get returns the node with the highest score for the given key. If this Hash
+// has no nodes, an empty string is returned.
+func (h *Hash) Get(key string) string {
+	keyBytes := []byte(key)
+
+	var maxScore uint32
+	var maxNode []byte
+	var score uint32
+
+	for _, node := range h.nodes {
+		score = h.hash(node.node, keyBytes)
+		if score > maxScore {
+			maxScore = score
+			maxNode = node.node
+		}
+	}
+
+	return string(maxNode)
+}
+
+// GetN returns n nodes for the given key, ordered by descending score.
+func (h *Hash) GetN(n int, key string) []string {
+	if len(h.nodes) == 0 || n == 0 {
+		return []string{}
+	}
+
+	if n > len(h.nodes) {
+		n = len(h.nodes)
+	}
+
+	keyBytes := []byte(key)
+	for i := 0; i < len(h.nodes); i++ {
+		h.nodes[i].score = h.hash(h.nodes[i].node, keyBytes)
+	}
+	sort.Sort(sort.Reverse(byScore(h.nodes)))
+
+	nodes := make([]string, n)
+	for i := 0; i < n; i++ {
+		nodes[i] = string(h.nodes[i].node)
+	}
+	return nodes
+}
+
+func (h *Hash) hash(node, key []byte) uint32 {
+	h.hasher.Reset()
+	h.hasher.Write(key)
+	h.hasher.Write(node)
+	return h.hasher.Sum32()
+}


### PR DESCRIPTION
The original DotNet and Go version's HashRing share different mechanism, making them incompatible with each other. And they both have some problems. The Go version performs fast, but result in poor distribution between nodes. DotNet version distributes quite well, but has a very bad performance (it needs to create 100*members list each call, and then Hash + LINQ)

Using Rendezvous hashtable by tysonmote solves the problem.
https://github.com/tysonmote/rendezvous/blob/master/rendezvous.go

See the results below:

Distribute 4 times 1000 random ids to 6 nodes:
OldDotnet
[NODE6:214 NODE1:171 NODE3:171 NODE2:165 NODE5:122 NODE4:158]
[NODE2:135 NODE5:135 NODE3:182 NODE1:175 NODE6:195 NODE4:178]
[NODE5:149 NODE4:185 NODE1:157 NODE2:135 NODE3:165 NODE6:209]
[NODE5:138 NODE4:169 NODE6:210 NODE3:190 NODE1:129 NODE2:164]
OldGO
[NODE1:7 NODE6:5 NODE4:7 NODE5:256 NODE2:720 NODE3:6]
[NODE4:3 NODE1:2 NODE6:2 NODE3:1 NODE2:797 NODE5:195]
[NODE2:844 NODE5:144 NODE4:2 NODE6:2 NODE3:7 NODE1:1]
[NODE5:227 NODE4:12 NODE6:16 NODE1:14 NODE3:12 NODE2:719]
Rendezvous
[NODE1:250 NODE2:124 NODE3:126 NODE4:131 NODE5:126 NODE6:244]
[NODE5:124 NODE4:127 NODE3:126 NODE2:123 NODE1:251 NODE6:249]
[NODE3:125 NODE4:127 NODE2:126 NODE6:249 NODE1:251 NODE5:122]
[NODE6:246 NODE5:127 NODE1:249 NODE2:125 NODE4:125 NODE3:128]

Go benchmark
Performance:
BenchmarkHashRingDotNet-4                   5000            295183 ns/op
BenchmarkHashRingGO-4                    2000000               891 ns/op
BenchmarkRendezvousCache-4               2000000               648 ns/op
BenchmarkRendezvousNonCache-4            1000000              1610 ns/op



