### PR TITLE
Fixes bug in transferring ownership of grains after adding members to a cluster

### DIFF
--- a/cluster/memberlist.go
+++ b/cluster/memberlist.go
@@ -11,7 +11,7 @@ import (
 //TODO: this needs to be implemented,we could send a `Request` to the membership actor, but this seems flaky.
 //a threadsafe map would be better
 func getMembers(kind string) []string {
-	res, err := memberlistPID.RequestFuture(&MemberByKindRequest{kind: kind, onlyAlive: true}, 5*time.Second).Result()
+	res, err := memberlistPID.RequestFuture(&MemberByKindRequest{kind: kind, onlyAlive: false}, 5*time.Second).Result()
 	if err == nil {
 		if t, ok := res.(*MemberByKindResponse); ok && len(t.members) > 0 {
 			return t.members

--- a/remote/activator_actor.go
+++ b/remote/activator_actor.go
@@ -122,7 +122,6 @@ func (*activator) Receive(context actor.Context) {
 				StatusCode: ResponseStatusCodePROCESSNAMEALREADYEXIST.ToInt32(),
 			}
 			context.Respond(response)
-			panic(err)
 		} else if aErr, ok := err.(*ActivatorError); ok {
 			response := &ActorPidResponse{
 				StatusCode: aErr.Code,


### PR DESCRIPTION
Preexisting grains do not get transferred to the new node's partition after a node is added to a cluster. Instead, it results in the following stack trace:

```
2017/10/12 11:16:34 [MAILBOX] [ACTOR] Recovering actor="172.18.0.4:8080/activator" reason="spawn: name exists" stacktrace="github.com/AsynkronIT/protoactor-go/remote.(*activator).Receive:125"
2017/10/12 11:16:34 [ACTOR] [SUPERVISION] actor="172.18.0.4:8080/activator" directive="RestartDirective" reason="spawn: name exists"
2017/10/12 11:16:34 [REMOTE] Activator received unknown message message=&{}
```

Also, getMembers should return all members for a partition kind, including those that are not alive. Otherwise, transferring of grains will fail, resulting in multiple activations.