### PR TITLE
Retry with exponential backoff

### DIFF
--- a/cluster/grain.go
+++ b/cluster/grain.go
@@ -19,12 +19,17 @@ type GrainCallOption func(*GrainCallConfig)
 type GrainCallConfig struct {
 	RetryCount int
 	Timeout    time.Duration
+	RetryAction func(n int)
 }
 
 func DefaultGrainCallConfig() *GrainCallConfig {
 	return &GrainCallConfig{
-		RetryCount: 1,
+		RetryCount: 10,
 		Timeout:    5 * time.Second,
+		RetryAction: func(i int) {
+			i++
+			time.Sleep( time.Duration(i * i * 50))
+		},
 	}
 }
 

--- a/examples/cluster-metrics/member/main.go
+++ b/examples/cluster-metrics/member/main.go
@@ -53,7 +53,7 @@ func main() {
 			log.Printf("Member Unavailable " + msg.Name())
 		case *cluster.MemberAvailableEvent:
 			log.Printf("Member Available " + msg.Name())
-		case *cluster.ClusterTopologyEvent:
+		case cluster.ClusterTopologyEvent:
 			log.Printf("Cluster Topology Poll")
 		}
 	})

--- a/examples/cluster/shared/protos_protoactor.go
+++ b/examples/cluster/shared/protos_protoactor.go
@@ -12,7 +12,6 @@ import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import (
 	math "math"
-	"time"
 )
 
 var _ = proto.Marshal

--- a/examples/cluster/shared/protos_protoactor.go
+++ b/examples/cluster/shared/protos_protoactor.go
@@ -10,7 +10,10 @@ import cluster "github.com/AsynkronIT/protoactor-go/cluster"
 
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
-import math "math"
+import (
+	math "math"
+	"time"
+)
 
 var _ = proto.Marshal
 var _ = fmt.Errorf
@@ -79,6 +82,10 @@ func (g *HelloGrain) SayHello(r *HelloRequest, options ...cluster.GrainCallOptio
 		res, err = fun()
 		if err == nil {
 			return res, nil
+		} else {
+			if conf.RetryAction != nil {
+				conf.RetryAction(i)
+			}
 		}
 	}
 	return nil, err

--- a/protobuf/protoc-gen-gograin/template.go
+++ b/protobuf/protoc-gen-gograin/template.go
@@ -77,6 +77,10 @@ func (g *{{ $service.Name }}Grain) {{ $method.Name }}(r *{{ $method.Input.Name }
 		res, err = fun()
 		if err == nil {
 			return res, nil
+		} else {
+			if conf.RetryAction != nil {
+				conf.RetryAction(i)
+			}
 		}
 	}
 	return nil, err


### PR DESCRIPTION
After debugging the cluster support I've identified that the main issue our users are facing with the cluster support is that if you start nodes in a burst, the consumer of a grain might be on a node that not yet see the other nodes knowing about the requested "kind".

By applying exponential backoff and retry, the problem goes away.