### PR TITLE
Grain code generation

### DIFF
--- a/cluster/grain.go
+++ b/cluster/grain.go
@@ -19,12 +19,17 @@ type GrainCallOption func(*GrainCallConfig)
 type GrainCallConfig struct {
 	RetryCount int
 	Timeout    time.Duration
+	RetryAction func(n int)
 }
 
 func DefaultGrainCallConfig() *GrainCallConfig {
 	return &GrainCallConfig{
-		RetryCount: 1,
+		RetryCount: 10,
 		Timeout:    5 * time.Second,
+		RetryAction: func(i int) {
+			i++
+			time.Sleep( time.Duration(i * i * 50))
+		},
 	}
 }
 

--- a/cluster/grain_context.go
+++ b/cluster/grain_context.go
@@ -1,0 +1,46 @@
+package cluster
+
+import (
+	"time"
+	"github.com/AsynkronIT/protoactor-go/actor"
+)
+
+type GrainContext interface {
+	// Watch registers the actor as a monitor for the specified PID
+	Watch(pid *actor.PID)
+
+	// Unwatch unregisters the actor as a monitor for the specified PID
+	Unwatch(pid *actor.PID)
+
+	// Message returns the current message to be processed
+	Message() interface{}
+
+	// Sender returns the PID of actor that sent currently processed message
+	Sender() *actor.PID
+
+	//Tell sends a message to the given PID
+	Tell(pid *actor.PID, message interface{})
+
+	//Request sends a message to the given PID and also provides a Sender PID
+	Request(pid *actor.PID, message interface{})
+
+	// RequestFuture sends a message to a given PID and returns a Future
+	RequestFuture(pid *actor.PID, message interface{}, timeout time.Duration) *actor.Future
+
+	// Self returns the PID for the current actor
+	Self() *actor.PID
+
+	// Spawn starts a new child actor based on props and named with a unique id
+	Spawn(props *actor.Props) *actor.PID
+
+	// SpawnPrefix starts a new child actor based on props and named using a prefix followed by a unique id
+	SpawnPrefix(props *actor.Props, prefix string) *actor.PID
+
+	// SpawnNamed starts a new child actor based on props and named using the specified name
+	//
+	// ErrNameExists will be returned if id already exists
+	SpawnNamed(props *actor.Props, id string) (*actor.PID, error)
+
+	// Returns a slice of the actors children
+	Children() []*actor.PID
+}

--- a/examples/cluster-metrics/member/main.go
+++ b/examples/cluster-metrics/member/main.go
@@ -53,7 +53,7 @@ func main() {
 			log.Printf("Member Unavailable " + msg.Name())
 		case *cluster.MemberAvailableEvent:
 			log.Printf("Member Available " + msg.Name())
-		case *cluster.ClusterTopologyEvent:
+		case cluster.ClusterTopologyEvent:
 			log.Printf("Cluster Topology Poll")
 		}
 	})

--- a/examples/cluster/shared/actors.go
+++ b/examples/cluster/shared/actors.go
@@ -7,15 +7,15 @@ type hello struct {
 	cluster.Grain
 }
 
-func (h *hello) SayHello(r *HelloRequest) (*HelloResponse, error) {
+func (h *hello) SayHello(r *HelloRequest, ctx cluster.GrainContext) (*HelloResponse, error) {
 	return &HelloResponse{Message: "hello " + r.Name + " from " + h.ID()}, nil
 }
 
-func (*hello) Add(r *AddRequest) (*AddResponse, error) {
+func (*hello) Add(r *AddRequest, ctx cluster.GrainContext) (*AddResponse, error) {
 	return &AddResponse{Result: r.A + r.B}, nil
 }
 
-func (*hello) VoidFunc(r *AddRequest) (*Unit, error) {
+func (*hello) VoidFunc(r *AddRequest, ctx cluster.GrainContext) (*Unit, error) {
 	return &Unit{}, nil
 }
 

--- a/examples/cluster/shared/protos_protoactor.go
+++ b/examples/cluster/shared/protos_protoactor.go
@@ -10,9 +10,7 @@ import cluster "github.com/AsynkronIT/protoactor-go/cluster"
 
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
-import (
-	math "math"
-)
+import math "math"
 
 var _ = proto.Marshal
 var _ = fmt.Errorf
@@ -32,11 +30,11 @@ func GetHelloGrain(id string) *HelloGrain {
 type Hello interface {
 	Init(id string)
 		
-	SayHello(*HelloRequest) (*HelloResponse, error)
+	SayHello(*HelloRequest, cluster.GrainContext) (*HelloResponse, error)
 		
-	Add(*AddRequest) (*AddResponse, error)
+	Add(*AddRequest, cluster.GrainContext) (*AddResponse, error)
 		
-	VoidFunc(*AddRequest) (*Unit, error)
+	VoidFunc(*AddRequest, cluster.GrainContext) (*Unit, error)
 		
 }
 type HelloGrain struct {
@@ -143,6 +141,10 @@ func (g *HelloGrain) Add(r *AddRequest, options ...cluster.GrainCallOption) (*Ad
 		res, err = fun()
 		if err == nil {
 			return res, nil
+		} else {
+			if conf.RetryAction != nil {
+				conf.RetryAction(i)
+			}
 		}
 	}
 	return nil, err
@@ -201,6 +203,10 @@ func (g *HelloGrain) VoidFunc(r *AddRequest, options ...cluster.GrainCallOption)
 		res, err = fun()
 		if err == nil {
 			return res, nil
+		} else {
+			if conf.RetryAction != nil {
+				conf.RetryAction(i)
+			}
 		}
 	}
 	return nil, err
@@ -232,7 +238,11 @@ func (a *HelloActor) Receive(ctx actor.Context) {
 	case *actor.Started:
 		a.inner = xHelloFactory()
 		id := ctx.Self().Id
-		a.inner.Init(id[7:len(id)]) //skip "remote$"
+		a.inner.Init(id[7:]) //skip "remote$"
+
+	case actor.AutoReceiveMessage: //pass
+	case actor.SystemMessage: //pass
+
 	case *cluster.GrainRequest:
 		switch msg.Method {
 			
@@ -242,7 +252,7 @@ func (a *HelloActor) Receive(ctx actor.Context) {
 			if err != nil {
 				log.Fatalf("[GRAIN] proto.Unmarshal failed %v", err)
 			}
-			r0, err := a.inner.SayHello(req)
+			r0, err := a.inner.SayHello(req, ctx)
 			if err == nil {
 				bytes, err := proto.Marshal(r0)
 				if err != nil {
@@ -261,7 +271,7 @@ func (a *HelloActor) Receive(ctx actor.Context) {
 			if err != nil {
 				log.Fatalf("[GRAIN] proto.Unmarshal failed %v", err)
 			}
-			r0, err := a.inner.Add(req)
+			r0, err := a.inner.Add(req, ctx)
 			if err == nil {
 				bytes, err := proto.Marshal(r0)
 				if err != nil {
@@ -280,7 +290,7 @@ func (a *HelloActor) Receive(ctx actor.Context) {
 			if err != nil {
 				log.Fatalf("[GRAIN] proto.Unmarshal failed %v", err)
 			}
-			r0, err := a.inner.VoidFunc(req)
+			r0, err := a.inner.VoidFunc(req, ctx)
 			if err == nil {
 				bytes, err := proto.Marshal(r0)
 				if err != nil {
@@ -302,13 +312,17 @@ func (a *HelloActor) Receive(ctx actor.Context) {
 	
 
 
-func init() {
-	
-	remote.Register("Hello", actor.FromProducer(func() actor.Actor {
-		return &HelloActor {}
-		})		)
-		
-}
+//Why has this been removed?
+//This should only be done on servers of the below Kinds
+//Clients should not be forced to also be servers
+
+//func init() {
+//	
+//	remote.Register("Hello", actor.FromProducer(func() actor.Actor {
+//		return &HelloActor {}
+//		})		)
+//	
+//}
 
 
 
@@ -316,15 +330,15 @@ func init() {
 //	cluster.Grain
 // }
 
-// func (*hello) SayHello(r *HelloRequest) (*HelloResponse, error) {
+// func (*hello) SayHello(r *HelloRequest, cluster.GrainContext) (*HelloResponse, error) {
 // 	return &HelloResponse{}, nil
 // }
 
-// func (*hello) Add(r *AddRequest) (*AddResponse, error) {
+// func (*hello) Add(r *AddRequest, cluster.GrainContext) (*AddResponse, error) {
 // 	return &AddResponse{}, nil
 // }
 
-// func (*hello) VoidFunc(r *AddRequest) (*Unit, error) {
+// func (*hello) VoidFunc(r *AddRequest, cluster.GrainContext) (*Unit, error) {
 // 	return &Unit{}, nil
 // }
 

--- a/examples/cluster/shared/protos_protoactor.go
+++ b/examples/cluster/shared/protos_protoactor.go
@@ -12,7 +12,6 @@ import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import (
 	math "math"
-	"time"
 )
 
 var _ = proto.Marshal

--- a/examples/cluster/shared/protos_protoactor.go
+++ b/examples/cluster/shared/protos_protoactor.go
@@ -10,7 +10,10 @@ import cluster "github.com/AsynkronIT/protoactor-go/cluster"
 
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
-import math "math"
+import (
+	math "math"
+	"time"
+)
 
 var _ = proto.Marshal
 var _ = fmt.Errorf
@@ -79,6 +82,10 @@ func (g *HelloGrain) SayHello(r *HelloRequest, options ...cluster.GrainCallOptio
 		res, err = fun()
 		if err == nil {
 			return res, nil
+		} else {
+			if conf.RetryAction != nil {
+				conf.RetryAction(i)
+			}
 		}
 	}
 	return nil, err

--- a/protobuf/protoc-gen-gograin/template.go
+++ b/protobuf/protoc-gen-gograin/template.go
@@ -77,6 +77,10 @@ func (g *{{ $service.Name }}Grain) {{ $method.Name }}(r *{{ $method.Input.Name }
 		res, err = fun()
 		if err == nil {
 			return res, nil
+		} else {
+			if conf.RetryAction != nil {
+				conf.RetryAction(i)
+			}
 		}
 	}
 	return nil, err


### PR DESCRIPTION
This PR adds the GrainContext param to codegenerated grains, which is a breaking change.
But the improvement is worth it as grains can now spawn child actors.

System and AutoReceive messages are also filtered from reaching the grain logger