### PR TITLE
Two minor fixes

### DIFF
--- a/actor/local_context.go
+++ b/actor/local_context.go
@@ -138,11 +138,15 @@ func (ctx *localContext) cancelTimer() {
 	if ctx.t != nil {
 		ctx.t.Stop()
 		ctx.t = nil
+		ctx.receiveTimeout = 0
 	}
 }
 
 func (ctx *localContext) receiveTimeoutHandler() {
-	ctx.self.Tell(receiveTimeoutMessage)
+	if ctx.t != nil {
+		ctx.cancelTimer()
+		ctx.self.Tell(receiveTimeoutMessage)
+	}
 }
 
 func (ctx *localContext) SetReceiveTimeout(d time.Duration) {


### PR DESCRIPTION
- Use go channel instead of mutex in logger.
- Reset timer when receiving timeout callback. Same as https://github.com/AsynkronIT/protoactor-dotnet/pull/346