### PR TITLE
Faster cluster

### DIFF
--- a/actor/future.go
+++ b/actor/future.go
@@ -22,10 +22,12 @@ func NewFuture(d time.Duration) *Future {
 	}
 
 	ref.pid = pid
-	ref.t = time.AfterFunc(d, func() {
-		ref.err = ErrTimeout
-		ref.Stop(pid)
-	})
+	if d > 0 {
+		ref.t = time.AfterFunc(d, func() {
+			ref.err = ErrTimeout
+			ref.Stop(pid)
+		})
+	}
 
 	return &ref.Future
 }
@@ -128,7 +130,9 @@ func (ref *futureProcess) Stop(pid *PID) {
 	}
 
 	ref.done = true
-	ref.t.Stop()
+	if ref.t != nil {
+		ref.t.Stop()
+	}
 	ProcessRegistry.Remove(pid)
 
 	ref.sendToPipes()

--- a/actor/future.go
+++ b/actor/future.go
@@ -22,7 +22,7 @@ func NewFuture(d time.Duration) *Future {
 	}
 
 	ref.pid = pid
-	if d > 0 {
+	if d >= 0 {
 		ref.t = time.AfterFunc(d, func() {
 			ref.err = ErrTimeout
 			ref.Stop(pid)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -69,8 +69,6 @@ func Get(name string, kind string) (*actor.PID, remote.ResponseStatusCode) {
 		return nil, remote.ResponseStatusCodeUNAVAILABLE
 	}
 
-	remotePartition := partitionForKind(address, kind)
-
 	//package the request as a remote.ActorPidRequest
 	req := &remote.ActorPidRequest{
 		Kind: kind,
@@ -78,6 +76,7 @@ func Get(name string, kind string) (*actor.PID, remote.ResponseStatusCode) {
 	}
 
 	//ask the DHT partition for this name to give us a PID
+	remotePartition := partitionForKind(address, kind)
 	f := remotePartition.RequestFuture(req, cfg.TimeoutTime)
 	err := f.Wait()
 	if err == actor.ErrTimeout {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -39,7 +39,7 @@ func Shutdown(graceful bool) {
 	if graceful {
 		cfg.ClusterProvider.Shutdown()
 		//This is to wait ownership transfering complete.
-		time.Sleep(2000)
+		time.Sleep(time.Millisecond * 2000)
 		stopMemberList()
 		stopPidCache()
 		stopPartition()

--- a/cluster/partition.go
+++ b/cluster/partition.go
@@ -131,7 +131,7 @@ func (state *partitionActor) spawn(msg *remote.ActorPidRequest, context actor.Co
 	}
 
 	//Create SpawningProcess and cache it in spawnings dictionary.
-	spawning = actor.NewFuture(0)
+	spawning = actor.NewFuture(-1)
 	state.spawnings[msg.Name] = spawning
 
 	//Await SpawningProcess

--- a/cluster/partition.go
+++ b/cluster/partition.go
@@ -131,7 +131,7 @@ func (state *partitionActor) spawn(msg *remote.ActorPidRequest, context actor.Co
 	}
 
 	//Create SpawningProcess and cache it in spawnings dictionary.
-	spawning = actor.NewFuture(cfg.TimeoutTime * 3)
+	spawning = actor.NewFuture(0)
 	state.spawnings[msg.Name] = spawning
 
 	//Await SpawningProcess

--- a/cluster/pid_cache.go
+++ b/cluster/pid_cache.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"sync"
+
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/eventstream"
 	"github.com/AsynkronIT/protoactor-go/log"
@@ -8,28 +10,41 @@ import (
 )
 
 var (
-	pidCacheActorPid *actor.PID
-	memberStatusSub  *eventstream.Subscription
+	pidCacheWatcher *actor.PID
+	memberStatusSub *eventstream.Subscription
+	pc              *pidCache
 )
 
-func spawnPidCacheActor() {
-	props := actor.FromProducer(newPidCacheActor())
-	pidCacheActorPid, _ = actor.SpawnNamed(props, "PidCache")
+type pidCache struct {
+	lock         *sync.Mutex
+	cache        map[string]*actor.PID
+	reverseCache map[string]string
 }
 
-func stopPidCacheActor() {
-	pidCacheActorPid.GracefulStop()
+func setupPidCache() {
+	pc = &pidCache{
+		lock:         &sync.Mutex{},
+		cache:        make(map[string]*actor.PID),
+		reverseCache: make(map[string]string),
+	}
+	props := actor.FromProducer(newPidCacheWatcher())
+	pidCacheWatcher, _ = actor.SpawnNamed(props, "PidCacheWatcher")
 }
 
-func newPidCacheActor() actor.Producer {
+func stopPidCache() {
+	pidCacheWatcher.GracefulStop()
+	pc = nil
+}
+
+func newPidCacheWatcher() actor.Producer {
 	return func() actor.Actor {
-		return &pidCachePartitionActor{}
+		return &pidCacheWatcherActor{}
 	}
 }
 
 func subscribePidCacheMemberStatusEventStream() {
 	memberStatusSub = eventstream.
-		Subscribe(pidCacheActorPid.Tell).
+		Subscribe(onMemberStatusEvent).
 		WithPredicate(func(m interface{}) bool {
 			_, ok := m.(MemberStatusEvent)
 			return ok
@@ -40,144 +55,137 @@ func unsubPidCacheMemberStatusEventStream() {
 	eventstream.Unsubscribe(memberStatusSub)
 }
 
-type pidCachePartitionActor struct {
-	Cache        map[string]*actor.PID
-	ReverseCache map[string]string
-}
-
-type keySet map[string]bool
-
-func (s keySet) add(val string)    { s[val] = true }
-func (s keySet) remove(val string) { delete(s, val) }
-
-type pidCacheRequest struct {
-	name string
-	kind string
-}
-
-func (p *pidCacheRequest) Hash() string {
-	return p.name
-}
-
-type removePidCacheRequest struct {
-	name string
-}
-
-func (p *removePidCacheRequest) Hash() string {
-	return p.name
-}
-
-type pidCacheResponse struct {
-	pid    *actor.PID
-	status remote.ResponseStatusCode
-}
-
-func (a *pidCachePartitionActor) Receive(ctx actor.Context) {
-	switch msg := ctx.Message().(type) {
-	case *actor.Started:
-		a.Cache = make(map[string]*actor.PID)
-		a.ReverseCache = make(map[string]string)
-
-	case *pidCacheRequest:
-		if pid, ok := a.Cache[msg.name]; ok {
-			//name was in cache, exit early
-			ctx.Respond(&pidCacheResponse{pid: pid})
-			return
-		}
-		name := msg.name
-		kind := msg.kind
-
-		address := getPartitionMember(name, kind)
-		if address == "" {
-			//No available member found
-			ctx.Respond(&pidCacheResponse{status: remote.ResponseStatusCodeUNAVAILABLE})
-			return
-		}
-
-		remotePartition := partitionForKind(address, kind)
-
-		//re-package the request as a remote.ActorPidRequest
-		req := &remote.ActorPidRequest{
-			Kind: kind,
-			Name: name,
-		}
-		//ask the DHT partition for this name to give us a PID
-		f := remotePartition.RequestFuture(req, cfg.TimeoutTime)
-		ctx.AwaitFuture(f, func(r interface{}, err error) {
-			if err == actor.ErrTimeout {
-				plog.Error("PidCache Pid request timeout")
-				ctx.Respond(&pidCacheResponse{status: remote.ResponseStatusCodeTIMEOUT})
-				return
-			} else if err != nil {
-				plog.Error("PidCache Pid request error", log.Error(err))
-				ctx.Respond(&pidCacheResponse{status: remote.ResponseStatusCodeERROR})
-				return
-			}
-
-			response, ok := r.(*remote.ActorPidResponse)
-			if !ok {
-				ctx.Respond(&pidCacheResponse{status: remote.ResponseStatusCodeERROR})
-				return
-			}
-
-			statusCode := remote.ResponseStatusCode(response.StatusCode)
-			switch statusCode {
-			case remote.ResponseStatusCodeOK:
-				key := response.Pid.String()
-
-				a.Cache[name] = response.Pid
-				//make a lookup from pid to name
-				a.ReverseCache[key] = name
-
-				//watch the pid so we know if the node or pid dies
-				ctx.Watch(response.Pid)
-				//tell the original requester that we have a response
-				ctx.Respond(&pidCacheResponse{response.Pid, statusCode})
-			default:
-				//forward to requester
-				ctx.Respond(&pidCacheResponse{response.Pid, statusCode})
-			}
-		})
-
+func onMemberStatusEvent(evn interface{}) {
+	switch msEvn := evn.(type) {
 	case *MemberLeftEvent:
-		address := msg.Name()
-		a.removeCacheByMemberAddress(address)
+		address := msEvn.Name()
+		pc.removeCacheByMemberAddress(address)
 	case *MemberRejoinedEvent:
-		address := msg.Name()
-		a.removeCacheByMemberAddress(address)
-	case *actor.Terminated:
-		a.removeCacheByPid(msg.Who)
-	case *removePidCacheRequest:
-		a.removeCacheByName(msg.name)
+		address := msEvn.Name()
+		pc.removeCacheByMemberAddress(address)
 	}
 }
 
-func (a *pidCachePartitionActor) removeCacheByPid(pid *actor.PID) {
+func getPid(name string, kind string) (*actor.PID, remote.ResponseStatusCode) {
+	//Check Cache
+	if pid, ok := pc.getCache(name); ok {
+		return pid, remote.ResponseStatusCodeOK
+	}
+
+	//Get Pid
+	address := getPartitionMember(name, kind)
+	if address == "" {
+		//No available member found
+		return nil, remote.ResponseStatusCodeUNAVAILABLE
+	}
+
+	remotePartition := partitionForKind(address, kind)
+
+	//package the request as a remote.ActorPidRequest
+	req := &remote.ActorPidRequest{
+		Kind: kind,
+		Name: name,
+	}
+
+	//ask the DHT partition for this name to give us a PID
+	f := remotePartition.RequestFuture(req, cfg.TimeoutTime)
+	err := f.Wait()
+	if err == actor.ErrTimeout {
+		plog.Error("PidCache Pid request timeout")
+		return nil, remote.ResponseStatusCodeTIMEOUT
+	} else if err != nil {
+		plog.Error("PidCache Pid request error", log.Error(err))
+		return nil, remote.ResponseStatusCodeERROR
+	}
+
+	r, _ := f.Result()
+	response, ok := r.(*remote.ActorPidResponse)
+	if !ok {
+		return nil, remote.ResponseStatusCodeERROR
+	}
+
+	statusCode := remote.ResponseStatusCode(response.StatusCode)
+	switch statusCode {
+	case remote.ResponseStatusCodeOK:
+		//save cache
+		pc.addCache(name, response.Pid)
+		//watch the pid so we know if the node or pid dies
+		pidCacheWatcher.Tell(&watchPidRequest{response.Pid})
+		//tell the original requester that we have a response
+		return response.Pid, statusCode
+	default:
+		//forward to requester
+		return response.Pid, statusCode
+	}
+}
+
+func (c *pidCache) getCache(name string) (*actor.PID, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	pid, ok := pc.cache[name]
+	return pid, ok
+}
+
+func (c *pidCache) addCache(name string, pid *actor.PID) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	key := pid.String()
+	c.cache[name] = pid
+	c.reverseCache[key] = name
+}
+
+func (c *pidCache) removeCacheByPid(pid *actor.PID) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	key := pid.String()
 	//get the virtual name from the pid
-	name, ok := a.ReverseCache[key]
+	name, ok := c.reverseCache[key]
 	if !ok {
 		//we don't have it, just ignore
 		return
 	}
 	//drop both lookups as this actor is now dead
-	delete(a.Cache, name)
-	delete(a.ReverseCache, key)
+	delete(c.cache, name)
+	delete(c.reverseCache, key)
 }
 
-func (a *pidCachePartitionActor) removeCacheByName(name string) {
-	if pid, ok := a.Cache[name]; ok {
+func (c *pidCache) removeCacheByName(name string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if pid, ok := c.cache[name]; ok {
 		key := pid.String()
-		delete(a.Cache, name)
-		delete(a.ReverseCache, key)
+		delete(c.cache, name)
+		delete(c.reverseCache, key)
 	}
 }
 
-func (a *pidCachePartitionActor) removeCacheByMemberAddress(address string) {
-	for name, pid := range a.Cache {
+func (c *pidCache) removeCacheByMemberAddress(address string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for name, pid := range c.cache {
 		if pid.Address == address {
-			delete(a.Cache, name)
-			delete(a.ReverseCache, pid.String())
+			delete(c.cache, name)
+			delete(c.reverseCache, pid.String())
 		}
+	}
+}
+
+type watchPidRequest struct {
+	pid *actor.PID
+}
+
+type pidCacheWatcherActor struct{}
+
+func (a *pidCacheWatcherActor) Receive(ctx actor.Context) {
+	switch msg := ctx.Message().(type) {
+	case *watchPidRequest:
+		ctx.Watch(msg.pid)
+	case *actor.Terminated:
+		pc.removeCacheByPid(msg.Who)
 	}
 }

--- a/cluster/pid_cache.go
+++ b/cluster/pid_cache.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/eventstream"
-	"github.com/AsynkronIT/protoactor-go/log"
-	"github.com/AsynkronIT/protoactor-go/remote"
 )
 
 var (
@@ -63,59 +61,6 @@ func onMemberStatusEvent(evn interface{}) {
 	case *MemberRejoinedEvent:
 		address := msEvn.Name()
 		pc.removeCacheByMemberAddress(address)
-	}
-}
-
-func getPid(name string, kind string) (*actor.PID, remote.ResponseStatusCode) {
-	//Check Cache
-	if pid, ok := pc.getCache(name); ok {
-		return pid, remote.ResponseStatusCodeOK
-	}
-
-	//Get Pid
-	address := getPartitionMember(name, kind)
-	if address == "" {
-		//No available member found
-		return nil, remote.ResponseStatusCodeUNAVAILABLE
-	}
-
-	remotePartition := partitionForKind(address, kind)
-
-	//package the request as a remote.ActorPidRequest
-	req := &remote.ActorPidRequest{
-		Kind: kind,
-		Name: name,
-	}
-
-	//ask the DHT partition for this name to give us a PID
-	f := remotePartition.RequestFuture(req, cfg.TimeoutTime)
-	err := f.Wait()
-	if err == actor.ErrTimeout {
-		plog.Error("PidCache Pid request timeout")
-		return nil, remote.ResponseStatusCodeTIMEOUT
-	} else if err != nil {
-		plog.Error("PidCache Pid request error", log.Error(err))
-		return nil, remote.ResponseStatusCodeERROR
-	}
-
-	r, _ := f.Result()
-	response, ok := r.(*remote.ActorPidResponse)
-	if !ok {
-		return nil, remote.ResponseStatusCodeERROR
-	}
-
-	statusCode := remote.ResponseStatusCode(response.StatusCode)
-	switch statusCode {
-	case remote.ResponseStatusCodeOK:
-		//save cache
-		pc.addCache(name, response.Pid)
-		//watch the pid so we know if the node or pid dies
-		pidCacheWatcher.Tell(&watchPidRequest{response.Pid})
-		//tell the original requester that we have a response
-		return response.Pid, statusCode
-	default:
-		//forward to requester
-		return response.Pid, statusCode
 	}
 }
 

--- a/mailbox/dispatcher.go
+++ b/mailbox/dispatcher.go
@@ -18,3 +18,17 @@ func (d goroutineDispatcher) Throughput() int {
 func NewDefaultDispatcher(throughput int) Dispatcher {
 	return goroutineDispatcher(throughput)
 }
+
+type synchronizedDispatcher int
+
+func (synchronizedDispatcher) Schedule(fn func()) {
+	fn()
+}
+
+func (d synchronizedDispatcher) Throughput() int {
+	return int(d)
+}
+
+func NewSynchronizedDispatcher(throughput int) Dispatcher {
+	return synchronizedDispatcher(throughput)
+}

--- a/remote/activator_actor.go
+++ b/remote/activator_actor.go
@@ -82,7 +82,7 @@ func SpawnNamed(address, name, kind string, timeout time.Duration) (*ActorPidRes
 		Kind: kind,
 	}, timeout).Result()
 	if err != nil {
-		return nil, errors.New("remote: Remote activating timed out")
+		return nil, err
 	}
 	switch msg := res.(type) {
 	case *ActorPidResponse:

--- a/remote/endpoint_manager.go
+++ b/remote/endpoint_manager.go
@@ -1,27 +1,47 @@
 package remote
 
 import (
+	"sync"
+	"sync/atomic"
+
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/eventstream"
-	"github.com/AsynkronIT/protoactor-go/mailbox"
 )
 
-var (
-	endpointManagerPID *actor.PID
-	endpointSub        *eventstream.Subscription
-)
+var endpointManager *endpointManagerValue
 
-func newEndpointManager(config *remoteConfig) actor.Producer {
-	return func() actor.Actor {
-		return &endpointManager{
-			config: config,
-		}
-	}
+type endpointLazy struct {
+	value    *endpoint
+	loadOnce sync.Once
+	unloaded uint32
 }
 
-func subscribeEndpointManager() {
-	endpointSub = eventstream.
-		Subscribe(endpointManagerPID.Tell).
+type endpoint struct {
+	writer  *actor.PID
+	watcher *actor.PID
+}
+
+type endpointManagerValue struct {
+	connections        *sync.Map
+	config             *remoteConfig
+	endpointSupervisor *actor.PID
+	endpointSub        *eventstream.Subscription
+}
+
+func startEndpointManager(config *remoteConfig) {
+	plog.Debug("Started EndpointManager")
+
+	props := actor.FromProducer(newEndpointSupervisor).WithSupervisor(actor.RestartingSupervisorStrategy())
+	endpointSupervisor := actor.Spawn(props)
+
+	endpointManager = &endpointManagerValue{
+		connections:        &sync.Map{},
+		config:             config,
+		endpointSupervisor: endpointSupervisor,
+	}
+
+	endpointManager.endpointSub = eventstream.
+		Subscribe(endpointManager.endpointEvent).
 		WithPredicate(func(m interface{}) bool {
 			switch m.(type) {
 			case *EndpointTerminatedEvent, *EndpointConnectedEvent:
@@ -31,111 +51,106 @@ func subscribeEndpointManager() {
 		})
 }
 
-func unsubEndpointManager() {
-	eventstream.Unsubscribe(endpointSub)
-}
-
-func spawnEndpointManager(config *remoteConfig) {
-	props := actor.
-		FromProducer(newEndpointManager(config)).
-		WithMailbox(mailbox.Bounded(config.endpointManagerQueueSize)).
-		WithSupervisor(actor.RestartingSupervisorStrategy())
-
-	endpointManagerPID = actor.Spawn(props)
-}
-
 func stopEndpointManager() {
-	endpointManagerPID.Tell(&StopEndpointManager{})
+	eventstream.Unsubscribe(endpointManager.endpointSub)
+	endpointManager.endpointSupervisor.GracefulStop()
+	endpointManager.endpointSub = nil
+	endpointManager.connections = nil
+	plog.Debug("Stopped EndpointManager")
 }
 
-type endpoint struct {
-	writer  *actor.PID
-	watcher *actor.PID
-}
-
-type endpointManager struct {
-	connections map[string]*endpoint
-	config      *remoteConfig
-}
-
-func (state *endpointManager) Receive(ctx actor.Context) {
-	switch msg := ctx.Message().(type) {
-	case *actor.Started:
-		state.connections = make(map[string]*endpoint)
-		plog.Debug("Started EndpointManager")
-	case *StopEndpointManager:
-		for _, edp := range state.connections {
-			edp.watcher.GracefulStop()
-			edp.writer.GracefulStop()
-		}
-		state.connections = make(map[string]*endpoint)
-		ctx.SetBehavior(state.Terminated)
-		plog.Debug("Stopped EndpointManager")
+func (em *endpointManagerValue) endpointEvent(evn interface{}) {
+	switch msg := evn.(type) {
 	case *EndpointTerminatedEvent:
-		address := msg.Address
-		if connected, endpoint := state.checkConnected(address); connected {
-			endpoint.watcher.Tell(msg)
-			state.removeEndpoint(address)
-		}
+		em.removeEndpoint(msg)
 	case *EndpointConnectedEvent:
-		address := msg.Address
-		endpoint := state.ensureConnected(address, ctx)
+		endpoint := em.ensureConnected(msg.Address)
 		endpoint.watcher.Tell(msg)
-	case *remoteTerminate:
-		address := msg.Watchee.Address
-		endpoint := state.ensureConnected(address, ctx)
-		endpoint.watcher.Tell(msg)
-	case *remoteWatch:
-		address := msg.Watchee.Address
-		endpoint := state.ensureConnected(address, ctx)
-		endpoint.watcher.Tell(msg)
-	case *remoteUnwatch:
-		address := msg.Watchee.Address
-		endpoint := state.ensureConnected(address, ctx)
-		endpoint.watcher.Tell(msg)
-	case *remoteDeliver:
-		address := msg.target.Address
-		endpoint := state.ensureConnected(address, ctx)
-		endpoint.writer.Tell(msg)
 	}
 }
 
-func (state *endpointManager) Terminated(ctx actor.Context) {}
-
-func (state *endpointManager) checkConnected(address string) (bool, *endpoint) {
-	e, ok := state.connections[address]
-	return ok, e
+func (em *endpointManagerValue) remoteTerminate(msg *remoteTerminate) {
+	address := msg.Watchee.Address
+	endpoint := em.ensureConnected(address)
+	endpoint.watcher.Tell(msg)
 }
 
-func (state *endpointManager) ensureConnected(address string, ctx actor.Context) *endpoint {
-	e, ok := state.connections[address]
+func (em *endpointManagerValue) remoteWatch(msg *remoteWatch) {
+	address := msg.Watchee.Address
+	endpoint := em.ensureConnected(address)
+	endpoint.watcher.Tell(msg)
+}
+
+func (em *endpointManagerValue) remoteUnwatch(msg *remoteUnwatch) {
+	address := msg.Watchee.Address
+	endpoint := em.ensureConnected(address)
+	endpoint.watcher.Tell(msg)
+}
+
+func (em *endpointManagerValue) remoteDeliver(msg *remoteDeliver) {
+	address := msg.target.Address
+	endpoint := em.ensureConnected(address)
+	endpoint.writer.Tell(msg)
+}
+
+func (em *endpointManagerValue) ensureConnected(address string) *endpoint {
+	e, ok := em.connections.Load(address)
 	if !ok {
-		e = &endpoint{
+		el := &endpointLazy{}
+		e, ok = em.connections.LoadOrStore(address, el)
+	}
+
+	el := e.(*endpointLazy)
+	el.loadOnce.Do(func() {
+		rst, _ := em.endpointSupervisor.RequestFuture(address, 0).Result()
+		el.value = rst.(*endpoint)
+	})
+
+	return el.value
+}
+
+func (em *endpointManagerValue) removeEndpoint(msg *EndpointTerminatedEvent) {
+	v, ok := em.connections.Load(msg.Address)
+	if ok {
+		le := v.(*endpointLazy)
+		if atomic.CompareAndSwapUint32(&le.unloaded, 0, 1) {
+			em.connections.Delete(msg.Address)
+			le.value.watcher.Tell(msg)
+			le.value.watcher.Stop()
+			le.value.writer.Stop()
+		}
+	}
+}
+
+type endpointSupervisor struct{}
+
+func newEndpointSupervisor() actor.Actor {
+	return &endpointSupervisor{}
+}
+
+func (state *endpointSupervisor) Receive(ctx actor.Context) {
+	if address, ok := ctx.Message().(string); ok {
+		e := &endpoint{
 			writer:  state.spawnEndpointWriter(address, ctx),
 			watcher: state.spawnEndpointWatcher(address, ctx),
 		}
-		state.connections[address] = e
-	}
-	return e
-}
-
-func (state *endpointManager) removeEndpoint(address string) {
-	if e, ok := state.connections[address]; ok {
-		e.watcher.Stop()
-		e.writer.Stop()
-		delete(state.connections, address)
+		ctx.Respond(e)
 	}
 }
 
-func (state *endpointManager) spawnEndpointWriter(address string, ctx actor.Context) *actor.PID {
+func (state *endpointSupervisor) HandleFailure(supervisor actor.Supervisor, child *actor.PID, rs *actor.RestartStatistics, reason interface{}, message interface{}) {
+	supervisor.RestartChildren(child)
+}
+
+func (state *endpointSupervisor) spawnEndpointWriter(address string, ctx actor.Context) *actor.PID {
 	props := actor.
-		FromProducer(newEndpointWriter(address, state.config)).
-		WithMailbox(newEndpointWriterMailbox(state.config.endpointWriterBatchSize, state.config.endpointWriterQueueSize))
+		FromProducer(newEndpointWriter(address, endpointManager.config)).
+		WithMailbox(newEndpointWriterMailbox(endpointManager.config.endpointWriterBatchSize, endpointManager.config.endpointWriterQueueSize))
 	pid := ctx.Spawn(props)
 	return pid
 }
 
-func (state *endpointManager) spawnEndpointWatcher(address string, ctx actor.Context) *actor.PID {
+func (state *endpointSupervisor) spawnEndpointWatcher(address string, ctx actor.Context) *actor.PID {
 	props := actor.
 		FromProducer(newEndpointWatcher(address))
 	pid := ctx.Spawn(props)

--- a/remote/endpoint_manager.go
+++ b/remote/endpoint_manager.go
@@ -97,7 +97,7 @@ func (em *endpointManagerValue) ensureConnected(address string) *endpoint {
 	e, ok := em.connections.Load(address)
 	if !ok {
 		el := &endpointLazy{}
-		e, ok = em.connections.LoadOrStore(address, el)
+		e, _ = em.connections.LoadOrStore(address, el)
 	}
 
 	el := e.(*endpointLazy)

--- a/remote/endpoint_manager.go
+++ b/remote/endpoint_manager.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/AsynkronIT/protoactor-go/mailbox"
+
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/eventstream"
 )
@@ -30,7 +32,9 @@ type endpointManagerValue struct {
 func startEndpointManager(config *remoteConfig) {
 	plog.Debug("Started EndpointManager")
 
-	props := actor.FromProducer(newEndpointSupervisor).WithSupervisor(actor.RestartingSupervisorStrategy())
+	props := actor.FromProducer(newEndpointSupervisor).
+		WithSupervisor(actor.RestartingSupervisorStrategy()).
+		WithDispatcher(mailbox.NewSynchronizedDispatcher(300))
 	endpointSupervisor := actor.Spawn(props)
 
 	endpointManager = &endpointManagerValue{

--- a/remote/endpoint_reader.go
+++ b/remote/endpoint_reader.go
@@ -6,6 +6,8 @@ import (
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/log"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type endpointReader struct {
@@ -13,10 +15,15 @@ type endpointReader struct {
 }
 
 func (s *endpointReader) Connect(ctx context.Context, req *ConnectRequest) (*ConnectResponse, error) {
+	if s.suspended {
+		return nil, status.Error(codes.Canceled, "Suspended")
+	}
+
 	return &ConnectResponse{DefaultSerializerId: DefaultSerializerID}, nil
 }
 
 func (s *endpointReader) Receive(stream Remoting_ReceiveServer) error {
+	targets := make([]*actor.PID, 100)
 	for {
 		if s.suspended {
 			time.Sleep(time.Millisecond * 500)
@@ -29,9 +36,17 @@ func (s *endpointReader) Receive(stream Remoting_ReceiveServer) error {
 			return err
 		}
 
+		//only grow pid lookup if needed
+		if len(batch.TargetNames) > len(targets) {
+			targets = make([]*actor.PID, len(batch.TargetNames))
+		}
+
+		for i := 0; i < len(batch.TargetNames); i++ {
+			targets[i] = actor.NewLocalPID(batch.TargetNames[i])
+		}
+
 		for _, envelope := range batch.Envelopes {
-			targetName := batch.TargetNames[envelope.Target]
-			pid := actor.NewLocalPID(targetName)
+			pid := targets[envelope.Target]
 			message, err := Deserialize(envelope.MessageData, batch.TypeNames[envelope.TypeId], envelope.SerializerId)
 			if err != nil {
 				plog.Debug("EndpointReader failed to deserialize", log.Error(err))
@@ -47,7 +62,7 @@ func (s *endpointReader) Receive(stream Remoting_ReceiveServer) error {
 					Watchee: msg.Who,
 					Watcher: pid,
 				}
-				endpointManagerPID.Tell(rt)
+				endpointManager.remoteTerminate(rt)
 			case actor.SystemMessage:
 				ref, _ := actor.ProcessRegistry.GetLocal(pid.Id)
 				ref.SendSystemMessage(pid, msg)

--- a/remote/messages.go
+++ b/remote/messages.go
@@ -35,3 +35,9 @@ type JsonMessage struct {
 var (
 	stopMessage interface{} = &actor.Stop{}
 )
+
+var (
+	ActorPidRespErr         interface{} = &ActorPidResponse{StatusCode: ResponseStatusCodeERROR.ToInt32()}
+	ActorPidRespTimeout     interface{} = &ActorPidResponse{StatusCode: ResponseStatusCodeTIMEOUT.ToInt32()}
+	ActorPidRespUnavailable interface{} = &ActorPidResponse{StatusCode: ResponseStatusCodeUNAVAILABLE.ToInt32()}
+)

--- a/remote/messages.go
+++ b/remote/messages.go
@@ -2,8 +2,6 @@ package remote
 
 import "github.com/AsynkronIT/protoactor-go/actor"
 
-type StopEndpointManager struct{}
-
 type EndpointTerminatedEvent struct {
 	Address string
 }

--- a/remote/remote_process.go
+++ b/remote/remote_process.go
@@ -27,7 +27,7 @@ func SendMessage(pid *actor.PID, message interface{}, sender *actor.PID, seriali
 		serializerID: serializerID,
 	}
 
-	endpointManagerPID.Tell(rd)
+	endpointManager.remoteDeliver(rd)
 }
 
 func (ref *process) SendSystemMessage(pid *actor.PID, message interface{}) {
@@ -39,13 +39,13 @@ func (ref *process) SendSystemMessage(pid *actor.PID, message interface{}) {
 			Watcher: msg.Watcher,
 			Watchee: pid,
 		}
-		endpointManagerPID.Tell(rw)
+		endpointManager.remoteWatch(rw)
 	case *actor.Unwatch:
 		ruw := &remoteUnwatch{
 			Watcher: msg.Watcher,
 			Watchee: pid,
 		}
-		endpointManagerPID.Tell(ruw)
+		endpointManager.remoteUnwatch(ruw)
 	default:
 		SendMessage(pid, message, nil, -1)
 	}

--- a/remote/server.go
+++ b/remote/server.go
@@ -36,8 +36,7 @@ func Start(address string, options ...RemotingOption) {
 	actor.ProcessRegistry.Address = address
 
 	spawnActivatorActor()
-	spawnEndpointManager(config)
-	subscribeEndpointManager()
+	startEndpointManager(config)
 
 	s = grpc.NewServer(config.serverOptions...)
 	edpReader = &endpointReader{}
@@ -49,8 +48,6 @@ func Start(address string, options ...RemotingOption) {
 func Shutdown(graceful bool) {
 	if graceful {
 		edpReader.suspend(true)
-
-		unsubEndpointManager()
 		stopEndpointManager()
 		stopActivatorActor()
 


### PR DESCRIPTION
This PR contains 3 Changes

-  **PartitionActor now spawns asynchronously.** (This has a huge spawn perf boost, since in current version, actors/grains are spawned one by one, stacking up round-trip time between partition node and activator node)
Detail implementation can be found here: https://github.com/AsynkronIT/protoactor-go/blob/cb07062c86fabb42e5fbd2208e0e56a47e5ed770/cluster/partition.go#L102-L186
It's achieved by storing spawning futures.
https://github.com/AsynkronIT/protoactor-go/blob/cb07062c86fabb42e5fbd2208e0e56a47e5ed770/cluster/partition.go#L134-L135

- **PidCache now uses ConcurrentMap instead of Actor.** This is simply because Dictionary + Lock is faster than PidCacheActor when getting the cache. I think it helps since PidCache needs to provide PID for every grain request.
https://github.com/PotterDai/protoactor-go/blob/b697338751304f39ded2629e991ac0b08dbe5fc9/cluster/pid_cache.go#L55-L61

- **EndpointManager now uses ConcurrentMap instead of Actor.** Same reason as above, it's faster especially for RemoteDeliver.

Some minor bug fixes:
- Rendezvous will crash if no member available. This is fixed in https://github.com/AsynkronIT/protoactor-go/commit/6179b955ef51e1875e3ff732f45538a52066da74#diff-108d82f54109c9e97b2391bafb7fc3b2
- Use Txn in ConsulProvider.

Some changes:
- I renamed some method/variable names to make code a bit cleaner.

