### PR TITLE
add Forward for context

### DIFF
--- a/actor/context.go
+++ b/actor/context.go
@@ -22,7 +22,10 @@ type Context interface {
 	//Tell sends a message to the given PID
 	Tell(pid *PID, message interface{})
 
-	//Request sends a message to the given PID and also provides a Sender PID
+	//Forward sends a message to the given PID and also provides message orginal Sender PID
+	Forward(pid *PID ,message interface{})
+
+	//Request sends a message to the given PID and also provides self as a Sender PID
 	Request(pid *PID, message interface{})
 
 	// RequestFuture sends a message to a given PID and returns a Future

--- a/actor/local_context.go
+++ b/actor/local_context.go
@@ -104,6 +104,15 @@ func (ctx *localContext) sendUserMessage(pid *PID, message interface{}) {
 	}
 }
 
+func (ctx *localContext)Forward(pid *PID ,message interface{})  {
+	env := &MessageEnvelope{
+		Header:  emptyMessageHeader,
+		Message: message,
+		Sender:  ctx.Sender(),
+	}
+	ctx.sendUserMessage(pid, env)
+}
+
 func (ctx *localContext) Request(pid *PID, message interface{}) {
 	env := &MessageEnvelope{
 		Header:  emptyMessageHeader,


### PR DESCRIPTION
Provides a `Forward `method to transfer Envelop-Header between multiple actors
implement for #200 