### PR TITLE
Avoid consensus problem when multiple nodes join/leave cluster in short amount of time.

### DIFF
--- a/cluster/partition.go
+++ b/cluster/partition.go
@@ -144,7 +144,7 @@ func (state *partitionActor) spawn(msg *remote.ActorPidRequest, context actor.Co
 		delete(state.spawnings, msg.Name)
 
 		//Check if exist in current partition dictionary
-		//This is necessary to avoid race condition during partition map transfering.
+		//This is necessary to avoid race condition during partition map transferring.
 		pid = state.partition[msg.Name]
 		if pid != nil {
 			response := &remote.ActorPidResponse{Pid: pid}


### PR DESCRIPTION
This PR is to avoid consensus problem when multiple nodes joining/leaving cluster in short amount of time.
It contains 2 Changes:
- Check if partition is the owner again when receive TakeOwnership message.
- Check if PID has been transferred when spawning new grain/actor finishes.

This also contains a bug fix:
- Avoid consensus problem when multiple nodes join/leave cluster in short amount of time. 