### PR TITLE
Revise Activator error handling.

### DIFF
--- a/remote/activator_actor.go
+++ b/remote/activator_actor.go
@@ -122,7 +122,6 @@ func (*activator) Receive(context actor.Context) {
 				StatusCode: ResponseStatusCodePROCESSNAMEALREADYEXIST.ToInt32(),
 			}
 			context.Respond(response)
-			panic(err)
 		} else if aErr, ok := err.(*ActivatorError); ok {
 			response := &ActorPidResponse{
 				StatusCode: aErr.Code,


### PR DESCRIPTION
NameAlreadyExist error should not panic.
Relates to: https://github.com/AsynkronIT/protoactor-dotnet/issues/369