### PR TITLE
Deprecate FromInstance

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ func (state *HelloActor) Receive(context actor.Context) {
 }
 
 func main() {
-    props := actor.FromInstance(&HelloActor{})
+    props := actor.FromProducer(func() actor.Actor { return &HelloActor{} })
     pid := actor.Spawn(props)
     pid.Tell(Hello{Who: "Roger"})
     console.ReadLine()
@@ -197,7 +197,7 @@ func (state *HelloActor) Receive(context actor.Context) {
 }
 
 func main() {
-    props := actor.FromInstance(&HelloActor{})
+    props := actor.FromProducer(func() actor.Actor { return &HelloActor{} })
     pid := actor.Spawn(props)
     actor.Tell(pid, Hello{Who: "Roger"})
 
@@ -331,7 +331,7 @@ func main() {
     remote.Start("localhost:8091")
 
     //register a name for our local actor so that it can be discovered remotely
-    remote.Register("hello", actor.FromInstance(&MyActor{}))
+    remote.Register("hello", actor.FromProducer(func() actor.Actor { return &MyActor{} }))
     console.ReadLine()
 }
 ```

--- a/actor/actor.go
+++ b/actor/actor.go
@@ -19,3 +19,30 @@ func (f ActorFunc) Receive(c Context) {
 }
 
 type SenderFunc func(c Context, target *PID, envelope *MessageEnvelope)
+
+//FromProducer creates a props with the given actor producer assigned
+func FromProducer(actorProducer Producer) *Props {
+	return &Props{actorProducer: actorProducer}
+}
+
+//FromFunc creates a props with the given receive func assigned as the actor producer
+func FromFunc(f ActorFunc) *Props {
+	return FromProducer(func() Actor { return f })
+}
+
+func FromSpawnFunc(spawn SpawnFunc) *Props {
+	return &Props{spawner: spawn}
+}
+
+//Deprecated: FromInstance is deprecated
+//Please use FromProducer(func() actor.Actor {...}) instead
+func FromInstance(template Actor) *Props {
+	return &Props{actorProducer: makeProducerFromInstance(template)}
+}
+
+//Deprecated: makeProducerFromInstance is deprecated.
+func makeProducerFromInstance(a Actor) Producer {
+	return func() Actor {
+		return a
+	}
+}

--- a/actor/child_test.go
+++ b/actor/child_test.go
@@ -90,7 +90,7 @@ func TestActorCanStopChildren(t *testing.T) {
 }
 
 func TestActorReceivesTerminatedFromWatched(t *testing.T) {
-	child := Spawn(FromInstance(nullReceive))
+	child := Spawn(FromFunc(nullReceive))
 	future := NewFuture(testTimeout)
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -109,7 +109,7 @@ func TestActorReceivesTerminatedFromWatched(t *testing.T) {
 		}
 	}
 
-	Spawn(FromInstance(r))
+	Spawn(FromFunc(r))
 	wg.Wait()
 	child.Stop()
 
@@ -117,7 +117,7 @@ func TestActorReceivesTerminatedFromWatched(t *testing.T) {
 }
 
 func TestFutureDoesTimeout(t *testing.T) {
-	pid := Spawn(FromInstance(nullReceive))
+	pid := Spawn(FromFunc(nullReceive))
 	_, err := pid.RequestFuture("", time.Millisecond).Result()
 	assert.EqualError(t, err, ErrTimeout.Error())
 }
@@ -131,7 +131,7 @@ func TestFutureDoesNotTimeout(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		c.Respond("foo")
 	}
-	pid := Spawn(FromInstance(r))
+	pid := Spawn(FromFunc(r))
 	reply, err := pid.RequestFuture("", 2*time.Second).Result()
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", reply)

--- a/actor/context_example_setBehavior_test.go
+++ b/actor/context_example_setBehavior_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 type setBehaviorActor struct {
-	sync.WaitGroup
+	*sync.WaitGroup
 }
 
 // Receive is the default message handler when an actor is started
@@ -28,14 +28,14 @@ func (f *setBehaviorActor) Other(context actor.Context) {
 
 // SetBehavior allows an actor to change its Receive handler, providing basic support for state machines
 func ExampleContext_setBehavior() {
-	a := &setBehaviorActor{}
-	a.Add(1)
-	pid := actor.Spawn(actor.FromInstance(a))
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	pid := actor.Spawn(actor.FromProducer(func() actor.Actor { return &setBehaviorActor{wg} }))
 	defer pid.GracefulStop()
 
 	pid.Tell("other")
 	pid.Tell("foo")
-	a.Wait()
+	wg.Wait()
 
 	// Output: foo
 }

--- a/actor/context_example_setReceiveTimeout_test.go
+++ b/actor/context_example_setReceiveTimeout_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type setReceiveTimeoutActor struct {
-	sync.WaitGroup
+	*sync.WaitGroup
 }
 
 // Receive is the default message handler when an actor is started
@@ -32,13 +32,13 @@ func (f *setReceiveTimeoutActor) Receive(context actor.Context) {
 // SetReceiveTimeout allows an actor to be notified repeatedly if it does not receive any messages
 // for a specified duration
 func ExampleContext_setReceiveTimeout() {
-	a := &setReceiveTimeoutActor{}
-	a.Add(1)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
 
-	pid := actor.Spawn(actor.FromInstance(a))
+	pid := actor.Spawn(actor.FromProducer(func() actor.Actor { return &setReceiveTimeoutActor{wg} }))
 	defer pid.GracefulStop()
 
-	a.Wait() // wait for the ReceiveTimeout message
+	wg.Wait() // wait for the ReceiveTimeout message
 
 	// Output: timed out
 }

--- a/actor/doc.go
+++ b/actor/doc.go
@@ -28,7 +28,7 @@ Alternatively, a type which conforms to the Actor interface, by defining a singl
 		// process messages
 	}
 
-	var props Props = actor.FromInstance(&MyActor{})
+	var props Props = actor.FromProducer(func() Actor { return &MyActor{} })
 
 Spawn and SpawnNamed use the given props to create a running instances of an actor. Once spawned, the actor is
 ready to process incoming messages. To spawn an actor with a unique name, use
@@ -48,14 +48,7 @@ An actor processes messages via its Receive handler. The signature of this funct
 	Receive(c actor.Context)
 
 The actor system guarantees that this method is called synchronously, therefore there is no requirement to protect
-shared state inside calls to this function. See the caution above
-
-CAUTION: whilst spawning multiple actors from the same Props will have their own private mailbox, using FromInstance or
-FromFunc will reference the same instance or function and therefore should not modify shared state. Use FromProducer,
-which accepts a function that produces new Actor instances:
-
-	var props Props = actor.FromProducer(func() actor.Actor { return &MyActor{} })
-
+shared state inside calls to this function.
 
 Communicating With Actors
 

--- a/actor/pid_test.go
+++ b/actor/pid_test.go
@@ -19,7 +19,7 @@ func TestStopFuture(t *testing.T) {
 
 	ID := "UniqueID"
 	{
-		props := FromInstance(&ShortLivingActor{})
+		props := FromProducer(func() Actor { return &ShortLivingActor{} })
 		a, _ := SpawnNamed(props, ID)
 
 		fut := a.StopFuture()

--- a/actor/props.go
+++ b/actor/props.go
@@ -88,13 +88,7 @@ func (props *Props) WithSpawnFunc(spawn SpawnFunc) *Props {
 
 //WithFunc assigns a receive func to the props
 func (props *Props) WithFunc(f ActorFunc) *Props {
-	props.actorProducer = makeProducerFromInstance(f)
-	return props
-}
-
-//WithInstance creates a custom actor producer from a given instance and assigns it to the props
-func (props *Props) WithInstance(a Actor) *Props {
-	props.actorProducer = makeProducerFromInstance(a)
+	props.actorProducer = func() Actor { return f }
 	return props
 }
 
@@ -104,27 +98,8 @@ func (props *Props) WithProducer(p Producer) *Props {
 	return props
 }
 
-//FromProducer creates a props with the given actor producer assigned
-func FromProducer(actorProducer Producer) *Props {
-	return &Props{actorProducer: actorProducer}
-}
-
-//FromFunc creates a props with the given receive func assigned as the actor producer
-func FromFunc(f ActorFunc) *Props {
-	return FromInstance(f)
-}
-
-//FromInstance creates a props with the given instance assigned as the actor producer
-func FromInstance(template Actor) *Props {
-	return &Props{actorProducer: makeProducerFromInstance(template)}
-}
-
-func makeProducerFromInstance(a Actor) Producer {
-	return func() Actor {
-		return a
-	}
-}
-
-func FromSpawnFunc(spawn SpawnFunc) *Props {
-	return &Props{spawner: spawn}
+//Deprecated: WithInstance is deprecated.
+func (props *Props) WithInstance(a Actor) *Props {
+	props.actorProducer = makeProducerFromInstance(a)
+	return props
 }

--- a/actor/spawn_test.go
+++ b/actor/spawn_test.go
@@ -37,7 +37,7 @@ func (a *GorgeousActor) Receive(context Context) {
 func TestLookupById(t *testing.T) {
 	ID := "UniqueID"
 	{
-		props := FromInstance(&GorgeousActor{Counter: Counter{value: 0}})
+		props := FromProducer(func() Actor { return &GorgeousActor{Counter: Counter{value: 0}} })
 		pid, _ := SpawnNamed(props, ID)
 		defer pid.Stop()
 
@@ -51,7 +51,7 @@ func TestLookupById(t *testing.T) {
 		assert.Equal(t, 1, value.(int))
 	}
 	{
-		props := FromInstance(&GorgeousActor{Counter: Counter{value: 0}})
+		props := FromProducer(func() Actor { return &GorgeousActor{Counter: Counter{value: 0}} })
 		pid, _ := SpawnNamed(props, ID)
 		result := pid.RequestFuture(Increment{}, testTimeout)
 		value, err := result.Result()

--- a/examples/backpressure/main.go
+++ b/examples/backpressure/main.go
@@ -49,7 +49,7 @@ func (p *producer) Receive(ctx actor.Context) {
 	switch msg := ctx.Message().(type) {
 	case *actor.Started:
 		//spawn our worker
-		workerProps := actor.FromInstance(&worker{}).WithMailbox(mailbox.Unbounded(&requestWorkBehavior{
+		workerProps := actor.FromProducer(func() actor.Actor { return &worker{} }).WithMailbox(mailbox.Unbounded(&requestWorkBehavior{
 			producer: ctx.Self(),
 		}))
 		p.worker = ctx.Spawn(workerProps)
@@ -87,7 +87,7 @@ type work struct {
 }
 
 func main() {
-	producerProps := actor.FromInstance(&producer{})
+	producerProps := actor.FromProducer(func() actor.Actor { return &producer{} })
 	actor.Spawn(producerProps)
 
 	console.ReadLine()

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -18,7 +18,7 @@ func (state *helloActor) Receive(context actor.Context) {
 }
 
 func main() {
-	props := actor.FromInstance(&helloActor{})
+	props := actor.FromProducer(func() actor.Actor { return &helloActor{} })
 	pid := actor.Spawn(props)
 	pid.Tell(&hello{Who: "Roger"})
 	console.ReadLine()

--- a/examples/lifecycleevents/main.go
+++ b/examples/lifecycleevents/main.go
@@ -27,7 +27,7 @@ func (state *helloActor) Receive(context actor.Context) {
 }
 
 func main() {
-	props := actor.FromInstance(&helloActor{})
+	props := actor.FromProducer(func() actor.Actor { return &helloActor{} })
 	actor := actor.Spawn(props)
 	actor.Tell(&hello{Who: "Roger"})
 

--- a/examples/mixins/main.go
+++ b/examples/mixins/main.go
@@ -44,7 +44,7 @@ func (p *NamerPlugin) OnOtherMessage(ctx actor.Context, usrMsg interface{}) {}
 
 func main() {
 	props := actor.
-		FromInstance(&myActor{}).
+		FromProducer(func() actor.Actor { return &myActor{} }).
 		WithMiddleware(
 			plugin.Use(&NamerPlugin{}),
 			middleware.Logger,

--- a/examples/persistence/main.go
+++ b/examples/persistence/main.go
@@ -79,7 +79,7 @@ func main() {
 	provider := NewProvider(3)
 	provider.InitState("persistent", 4, 3)
 
-	props := actor.FromInstance(&Actor{}).WithMiddleware(persistence.Using(provider))
+	props := actor.FromProducer(func() actor.Actor { return &Actor{} }).WithMiddleware(persistence.Using(provider))
 	pid, _ := actor.SpawnNamed(props, "persistent")
 	pid.Tell(&Message{protoMsg: protoMsg{state: "state4"}})
 	pid.Tell(&Message{protoMsg: protoMsg{state: "state5"}})

--- a/plugin/passivation_test.go
+++ b/plugin/passivation_test.go
@@ -25,7 +25,7 @@ func TestPassivation(t *testing.T) {
 	UnitOfTime := time.Duration(200 * time.Millisecond)
 	PassivationDuration := time.Duration(3 * UnitOfTime)
 	props := actor.
-		FromInstance(&SmartActor{}).
+		FromProducer(func() actor.Actor { return &SmartActor{} }).
 		WithMiddleware(Use(&PassivationPlugin{Duration: PassivationDuration}))
 
 	pid := actor.Spawn(props)

--- a/router/consistent_hash_router_test.go
+++ b/router/consistent_hash_router_test.go
@@ -60,8 +60,7 @@ func (state *managerActor) Receive(context actor.Context) {
 				//log.Println(v)
 
 			} else {
-
-				props := actor.FromInstance(&routerActor{})
+				props := actor.FromProducer(func() actor.Actor { return &routerActor{} })
 				pid := actor.Spawn(props)
 				state.rpid.Tell(&router.AddRoutee{pid})
 				//log.Println(v)
@@ -80,15 +79,15 @@ func TestConcurrency(t *testing.T) {
 	}
 
 	wait.Add(100 * 10000)
-	rpid := actor.Spawn(router.NewConsistentHashPool(100).WithInstance(&routerActor{}))
+	rpid := actor.Spawn(router.NewConsistentHashPool(100).WithProducer(func() actor.Actor { return &routerActor{} }))
 
-	props := actor.FromInstance(&tellerActor{})
+	props := actor.FromProducer(func() actor.Actor { return &tellerActor{} })
 	for i := 0; i < 10000; i++ {
 		pid := actor.Spawn(props)
 		pid.Tell(&myMessage{i, rpid})
 	}
 
-	props = actor.FromInstance(&managerActor{})
+	props = actor.FromProducer(func() actor.Actor { return &managerActor{} })
 	pid := actor.Spawn(props)
 	pid.Tell(&getRoutees{rpid})
 	wait.Wait()

--- a/router/routeractor_group.go
+++ b/router/routeractor_group.go
@@ -10,7 +10,7 @@ type groupRouterActor struct {
 	props  *actor.Props
 	config RouterConfig
 	state  Interface
-	wg     sync.WaitGroup
+	wg     *sync.WaitGroup
 }
 
 func (a *groupRouterActor) Receive(context actor.Context) {

--- a/router/routeractor_pool.go
+++ b/router/routeractor_pool.go
@@ -11,7 +11,7 @@ type poolRouterActor struct {
 	props  *actor.Props
 	config RouterConfig
 	state  Interface
-	wg     sync.WaitGroup
+	wg     *sync.WaitGroup
 }
 
 func (a *poolRouterActor) Receive(context actor.Context) {


### PR DESCRIPTION
@rogeralsing As we discussed before, this PR deprecates FromInstance.
The function is still there, https://github.com/PotterDai/protoactor-go/blob/fe6d25a4c76a6a64bc61d18ab561b0ce1234124b/actor/actor.go#L37
but is marked Deprecated.

All "FromInstance"s are removed from examples and documentations to avoid future confusion.