### PR TITLE
Fix  x86-32 64bit alignment bug

### DIFF
--- a/actor/process_registry.go
+++ b/actor/process_registry.go
@@ -7,10 +7,10 @@ import (
 )
 
 type ProcessRegistryValue struct {
+	SequenceID     uint64
 	Address        string
 	LocalPIDs      cmap.ConcurrentMap
 	RemoteHandlers []AddressResolver
-	SequenceID     uint64
 }
 
 var (

--- a/internal/queue/goring/queue.go
+++ b/internal/queue/goring/queue.go
@@ -13,8 +13,8 @@ type ringBuffer struct {
 }
 
 type Queue struct {
-	content *ringBuffer
 	len     int64
+	content *ringBuffer
 	lock    sync.Mutex
 }
 


### PR DESCRIPTION
Mentioned here:
https://golang.org/pkg/sync/atomic/#pkg-note-BUG
https://github.com/AsynkronIT/protoactor-go/issues/227