### PR TITLE
Fix problem with detection of endpoint termination

### DIFF
--- a/remote/endpoint_writer.go
+++ b/remote/endpoint_writer.go
@@ -91,6 +91,13 @@ func (state *endpointWriter) sendEnvelopes(msg []interface{}, ctx actor.Context)
 	var targetID int32
 	var serializerID int32
 	for i, tmp := range msg {
+
+		switch unwrapped := tmp.(type) {
+		case *EndpointTerminatedEvent, EndpointTerminatedEvent:
+			plog.Debug("Handling array wrapped terminate event", log.String("address", state.address), log.Object("msg", unwrapped))
+			ctx.Self().Stop()
+			return
+		}
 		rd := tmp.(*remoteDeliver)
 
 		if rd.serializerID == -1 {


### PR DESCRIPTION
When a endpoint is terminated a EndpointTerminatedEvent is emitted using the eventstream.

When this message is processed it seems to be wrapped in a slice. This leads to a processing inside of sendEnvelopes which causes the actor to fail and be restarted. 

To avoid this problem I added a additional handling inside of sendEnvelopes. This can only be considered as a temporary solution. It seems that the event should not be wrapped in the first place.