### PR TITLE
Corrected error in the lifecycle example

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ func (state *HelloActor) Receive(context actor.Context) {
 func main() {
     props := actor.FromProducer(func() actor.Actor { return &HelloActor{} })
     pid := actor.Spawn(props)
-    actor.Tell(pid, Hello{Who: "Roger"})
+    pid.Tell(Hello{Who: "Roger"})
 
     //why wait?
     //Stop is a system message and is not processed through the user message mailbox


### PR DESCRIPTION
There was a error in the example for illustrating the lifecycle of a actor.