### PR TITLE
Fix nil pointer access when no maxMember was found

### DIFF
--- a/cluster/rendezvous.go
+++ b/cluster/rendezvous.go
@@ -50,7 +50,10 @@ func (r *Rendezvous) GetByRdv(key string) string {
 		}
 	}
 
-	return maxMember.Address()
+	if maxMember != nil {
+		return maxMember.Address()
+	}
+	return ""
 }
 
 func (r *Rendezvous) UpdateRdv() {


### PR DESCRIPTION
If no members are available there is no maxMember from which an address
can be accessed.

This fix returns an empty string if no such member exists.