### PR TITLE
allow extraction of PIDs of cluster members

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -100,6 +100,19 @@ func Get(name string, kind string) (*actor.PID, remote.ResponseStatusCode) {
 	}
 }
 
+// Get PIDs of members for the specified kind
+func GetMemberPIDs(kind string) actor.PIDSet {
+	pids := actor.PIDSet{}
+	for _, value := range memberList.members {
+		for _, memberKind := range value.Kinds {
+			if kind == memberKind  {
+				pids.Add(actor.NewPID(value.Address(), kind))
+			}
+		}
+	}
+	return pids
+}
+
 //RemoveCache at PidCache
 func RemoveCache(name string) {
 	pidCache.removeCacheByName(name)


### PR DESCRIPTION
Subscribing to cluster.MemberStatusEvents was error prone, which
resulted in visibility issues for actors that relied on an up-to-date
topology of the cluster.

By allowing the access of the PIDs of all cluster members of a specific kind,
these actors are able to work properly.