### PR TITLE
Fix nil pointer access on GetMemberPIDs

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -103,9 +103,12 @@ func Get(name string, kind string) (*actor.PID, remote.ResponseStatusCode) {
 // Get PIDs of members for the specified kind
 func GetMemberPIDs(kind string) actor.PIDSet {
 	pids := actor.PIDSet{}
+	if memberList == nil {
+		return pids
+	}
 	for _, value := range memberList.members {
 		for _, memberKind := range value.Kinds {
-			if kind == memberKind  {
+			if kind == memberKind {
 				pids.Add(actor.NewPID(value.Address(), kind))
 			}
 		}


### PR DESCRIPTION
GetMemberPIDs accesses a nil pointer if the cluster has not
yet been initialized. This is rather inconvenient if unit
tests (that should not need a consul) access the memberList.