### PR TITLE
Fix concurrent map iteration and map write error on GetMemberPIDs

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -100,8 +100,11 @@ func Get(name string, kind string) (*actor.PID, remote.ResponseStatusCode) {
 	}
 }
 
-// Get PIDs of members for the specified kind
+// GetMemberPIDs returns PIDs of members for the specified kind
 func GetMemberPIDs(kind string) actor.PIDSet {
+	memberList.mutex.RLock()
+	defer memberList.mutex.RUnlock()
+
 	pids := actor.PIDSet{}
 	if memberList == nil {
 		return pids


### PR DESCRIPTION
Hey there,

I received the following error stack trace and it seems to be a locking problem with the `GetMemberPIDs` function.

```
fatal error: concurrent map iteration and map write

goroutine 4229872 [running]:
runtime.throw(0xd033c3, 0x26)
	/usr/local/go/src/runtime/panic.go:616 +0x81 fp=0xc4206b5a88 sp=0xc4206b5a68 pc=0x42ad31
runtime.mapiternext(0xc4206b5c38)
	/usr/local/go/src/runtime/hashmap.go:747 +0x55c fp=0xc4206b5b18 sp=0xc4206b5a88 pc=0x408b7c
rs.daimler.com/apptwin/vendor/github.com/AsynkronIT/protoactor-go/cluster.GetMemberPIDs(0xcf8067, 0x1b, 0xb9f600, 0xc436dfa2d0, 0xc42565a300, 0xc4209c5d70)
...
```