### PR TITLE
Fix nil pointer exception for not yet initialised memberList

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -102,13 +102,14 @@ func Get(name string, kind string) (*actor.PID, remote.ResponseStatusCode) {
 
 // GetMemberPIDs returns PIDs of members for the specified kind
 func GetMemberPIDs(kind string) actor.PIDSet {
-	memberList.mutex.RLock()
-	defer memberList.mutex.RUnlock()
-
 	pids := actor.PIDSet{}
 	if memberList == nil {
 		return pids
 	}
+
+	memberList.mutex.RLock()
+	defer memberList.mutex.RUnlock()
+
 	for _, value := range memberList.members {
 		for _, memberKind := range value.Kinds {
 			if kind == memberKind {


### PR DESCRIPTION
The lock obviously needs to come after the nil check. 

Sorry for the premature initial PR.