### PR TITLE
Fix the networking example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ func (state *MyActor) Receive(context actor.Context) {
 func main() {
     remote.Start("localhost:8090")
 
-    pid := actor.SpawnTemplate(&MyActor{})
+    props := actor.FromProducer(func() actor.Actor { return &MyActor{} })
+    pid := actor.Spawn(props)
     message := &messages.Echo{Message: "hej", Sender: pid}
 
     //this is the remote actor we want to communicate with

--- a/README.md
+++ b/README.md
@@ -331,8 +331,9 @@ func (*MyActor) Receive(context actor.Context) {
 func main() {
     remote.Start("localhost:8091")
 
-    //register a name for our local actor so that it can be discovered remotely
-    remote.Register("hello", actor.FromProducer(func() actor.Actor { return &MyActor{} }))
+    //spawn a named actor "myactor" so it can be discovered remotely
+    props := actor.FromProducer(func() actor.Actor { return &MyActor{} })
+    actor.SpawnNamed(props, "myactor")
     console.ReadLine()
 }
 ```


### PR DESCRIPTION
I was working my way through the README and noticed a couple issues with the networking example.

* SpawnTemplate is not defined in the actor package so use FromProducer
instead. This is the most commonly used spawn function in the README so
this change makes it more consistent as well.
* The networking example was not working correctly and was causing remote
messages to be delivered as deadletters. Spawn a named actor "myactor"
that matches what node1 is looking for.

Fixes #262