### PR TITLE
fix for removing in slice of  pointers

### DIFF
--- a/cluster/weighted/weighted_member_strategy.go
+++ b/cluster/weighted/weighted_member_strategy.go
@@ -34,7 +34,10 @@ func (m *WeightedMemberStrategy) UpdateMember(member *cluster.MemberStatus) {
 func (m *WeightedMemberStrategy) RemoveMember(member *cluster.MemberStatus) {
 	for i, mb := range m.members {
 		if mb.Address() == member.Address() {
-			m.members = append(m.members[:i], m.members[i+1:]...)
+			copy(m.members[i:], m.members[i+1:])
+			m.members[len(m.members)-1] = nil
+			m.members = m.members[:len(m.members)-1]
+
 			m.wrr.UpdateRR()
 			m.rdv.UpdateRdv()
 			return


### PR DESCRIPTION
In [this atricle](https://github.com/golang/go/wiki/SliceTricks) is described the case when 'the type of the element is a pointer' have a potential memory leak problem. The suggested soultion was implemented. @PotterDai what do you think about it?