### PR TITLE
Fix looping endpoint writer

### DIFF
--- a/remote/endpoint_manager.go
+++ b/remote/endpoint_manager.go
@@ -149,7 +149,17 @@ func (state *endpointSupervisor) Receive(ctx actor.Context) {
 }
 
 func (state *endpointSupervisor) HandleFailure(supervisor actor.Supervisor, child *actor.PID, rs *actor.RestartStatistics, reason interface{}, message interface{}) {
-	supervisor.RestartChildren(child)
+	endpointManager.connections.Range(func(address, value interface{}) bool {
+		le := value.(*endpointLazy)
+		ep := le.valueFunc()
+
+		if ep.writer.Equal(child) || ep.watcher.Equal(child) {
+			supervisor.RestartChildren(child)
+			return false
+		}
+
+		return true
+	})
 }
 
 func (state *endpointSupervisor) spawnEndpointWriter(address string, ctx actor.Context) *actor.PID {


### PR DESCRIPTION
Hey there,

When remote actors in consul become unavailable and ultimately leave the cluster two events are published on the `eventstream`:
1. `MemberUnavailableEvent` and 
2. `MemberLeftEvent`.

In our case we query all remote actors via `cluster.GetMemberPIDs`. This function also returns actors that recently have become unavailable (which is intended as we're using consistent hash routing). Hence sending a message to them results in spawning an `EndpointWriter` actor that gets stuck in an initialisation loop. 

The `EndpointWriter` actor tries to connect to the unavailable endpoint, fails, sleeps 2s, panics and gets restated by the `endpointSupervisor`s supervisor strategy. When the unavailable remote actor eventually gets removed from the consul service list an `EndpointTerminatedEvent` is correctly published on the `eventstream` which is also received by the looping `EndpointWriter` actor (in it's mailbox) and usually handled appropriately. Unfortunately when the actor is stuck in the initialisation loop it never gets to handling this event and therefore spams the log output with `EndpointWriter failed to connect` etc. 

On the other hand the `EndpointTerminatedEvent` correctly updates the `EndpointManager`s `connections` map. Therefore only restarting the `EndpointWriter` actor if its endpoint is in the `connections` map seems appropriate - even besides this problem I'm describing here. This PR updates the `HandleFailure` method to only restart child actors if the corresponding endpoint is found in the connections map.

Cheers,
Dennis