### PR TITLE
Spawn middleware

### DIFF
--- a/actor/actor_context.go
+++ b/actor/actor_context.go
@@ -358,7 +358,14 @@ func (ctx *actorContext) SpawnNamed(props *Props, name string) (*PID, error) {
 		panic(errors.New("Props used to spawn child cannot have GuardianStrategy"))
 	}
 
-	pid, err := props.spawn(ctx.self.Id+"/"+name, ctx.self)
+	var pid *PID
+	var err error
+	if ctx.props.spawnMiddlewareChain != nil {
+		pid, err = ctx.props.spawnMiddlewareChain(ctx.self.Id+"/"+name, props, ctx)
+	} else {
+		pid, err = props.spawn(ctx.self.Id+"/"+name, ctx)
+	}
+
 	if err != nil {
 		return pid, err
 	}

--- a/actor/actor_context_test.go
+++ b/actor/actor_context_test.go
@@ -21,7 +21,7 @@ func TestActorContext_SpawnNamed(t *testing.T) {
 		},
 	}
 
-	parent := &actorContext{self: NewLocalPID("foo")}
+	parent := &actorContext{self: NewLocalPID("foo"), props: props}
 	child, err := parent.SpawnNamed(props, "bar")
 	assert.NoError(t, err)
 	assert.Equal(t, parent.Children()[0], child)
@@ -204,7 +204,7 @@ func benchmarkActorContext_SpawnWithMiddlewareN(n int, b *testing.B) {
 		props = props.WithSenderMiddleware(middlwareFn)
 	}
 
-	parent := &actorContext{self: NewLocalPID("foo")}
+	parent := &actorContext{self: NewLocalPID("foo"), props: props}
 	for i := 0; i < b.N; i++ {
 		parent.Spawn(props)
 	}

--- a/actor/actor_context_test.go
+++ b/actor/actor_context_test.go
@@ -15,7 +15,7 @@ func TestActorContext_SpawnNamed(t *testing.T) {
 	defer removeMockProcess(pid)
 
 	props := &Props{
-		spawner: func(id string, _ *Props, _ *PID) (*PID, error) {
+		spawner: func(id string, _ *Props, _ SpawnerContext) (*PID, error) {
 			assert.Equal(t, "foo/bar", id)
 			return NewLocalPID(id), nil
 		},

--- a/actor/context.go
+++ b/actor/context.go
@@ -21,6 +21,11 @@ type ReceiverContext interface {
 	receiverPart
 }
 
+type SpawnerContext interface {
+	infoPart
+	spawnerPart
+}
+
 type infoPart interface {
 	// Parent returns the PID for the current actors parent
 	Parent() *PID

--- a/actor/middleware/propagator/middlewarepropagation.go
+++ b/actor/middleware/propagator/middlewarepropagation.go
@@ -1,0 +1,59 @@
+package propagator
+
+import (
+	"github.com/AsynkronIT/protoactor-go/actor"
+)
+
+type MiddlewarePropagator struct {
+	spawnMiddleware    []actor.SpawnMiddleware
+	senderMiddleware   []actor.SenderMiddleware
+	receiverMiddleware []actor.ReceiverMiddleware
+	contextDecorators  []actor.ContextDecorator
+}
+
+func New() *MiddlewarePropagator {
+	return &MiddlewarePropagator{}
+}
+
+func (propagator *MiddlewarePropagator) WithItselfForwarded() *MiddlewarePropagator {
+	return propagator.WithSpawnMiddleware(propagator.SpawnMiddleware)
+}
+
+func (propagator *MiddlewarePropagator) WithSpawnMiddleware(middleware ...actor.SpawnMiddleware) *MiddlewarePropagator {
+	propagator.spawnMiddleware = append(propagator.spawnMiddleware, middleware...)
+	return propagator
+}
+
+func (propagator *MiddlewarePropagator) WithSenderMiddleware(middleware ...actor.SenderMiddleware) *MiddlewarePropagator {
+	propagator.senderMiddleware = append(propagator.senderMiddleware, middleware...)
+	return propagator
+}
+
+func (propagator *MiddlewarePropagator) WithReceiverMiddleware(middleware ...actor.ReceiverMiddleware) *MiddlewarePropagator {
+	propagator.receiverMiddleware = append(propagator.receiverMiddleware, middleware...)
+	return propagator
+}
+
+func (propagator *MiddlewarePropagator) WithContextDecorator(decorators ...actor.ContextDecorator) *MiddlewarePropagator {
+	propagator.contextDecorators = append(propagator.contextDecorators, decorators...)
+	return propagator
+}
+
+func (propagator *MiddlewarePropagator) SpawnMiddleware(next actor.SpawnFunc) actor.SpawnFunc {
+	return func(id string, props *actor.Props, parentContext actor.SpawnerContext) (pid *actor.PID, e error) {
+		if propagator.spawnMiddleware != nil {
+			props = props.WithSpawnMiddleware(propagator.spawnMiddleware...)
+		}
+		if propagator.senderMiddleware != nil {
+			props = props.WithSenderMiddleware(propagator.senderMiddleware...)
+		}
+		if propagator.receiverMiddleware != nil {
+			props = props.WithReceiverMiddleware(propagator.receiverMiddleware...)
+		}
+		if propagator.contextDecorators != nil {
+			props = props.WithContextDecorator(propagator.contextDecorators...)
+		}
+		pid, err := next(id, props, parentContext)
+		return pid, err
+	}
+}

--- a/actor/middleware/propagator/middlewarepropagation_test.go
+++ b/actor/middleware/propagator/middlewarepropagation_test.go
@@ -1,0 +1,43 @@
+package propagator
+
+import (
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/magiconair/properties/assert"
+	"sync"
+	"testing"
+)
+
+func TestPropagator(t *testing.T) {
+
+	mutex := &sync.Mutex{}
+	spawningCounter := 0
+
+	propagator := New().
+		WithItselfForwarded().
+		WithSpawnMiddleware(func(next actor.SpawnFunc) actor.SpawnFunc {
+			return func(id string, props *actor.Props, parentContext actor.SpawnerContext) (pid *actor.PID, e error) {
+				mutex.Lock()
+				spawningCounter++
+				mutex.Unlock()
+				return next(id, props, parentContext)
+			}
+		})
+
+	var start func(input int) *actor.Props
+	start = func(input int) *actor.Props {
+		return actor.PropsFromFunc(func(c actor.Context) {
+			switch c.Message().(type) {
+			case *actor.Started:
+				if input > 0 {
+					c.Spawn(start(input - 1))
+				}
+			}
+		})
+	}
+
+	root := actor.EmptyRootContext().WithSpawnMiddleware(propagator.SpawnMiddleware).Spawn(start(5))
+
+	root.StopFuture().Wait()
+
+	assert.Equal(t, spawningCounter, 5)
+}

--- a/actor/middleware/propagator/middlewarepropagation_test.go
+++ b/actor/middleware/propagator/middlewarepropagation_test.go
@@ -2,7 +2,7 @@ package propagator
 
 import (
 	"github.com/AsynkronIT/protoactor-go/actor"
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
 )

--- a/actor/middleware_chain.go
+++ b/actor/middleware_chain.go
@@ -35,3 +35,15 @@ func makeContextDecoratorChain(decorator []ContextDecorator, lastDecorator Conte
 	}
 	return h
 }
+
+func makeSpawnMiddlewareChain(spawnMiddleware []SpawnMiddleware, lastSpawn SpawnFunc) SpawnFunc {
+	if len(spawnMiddleware) == 0 {
+		return nil
+	}
+
+	h := spawnMiddleware[len(spawnMiddleware)-1](lastSpawn)
+	for i := len(spawnMiddleware) - 2; i >= 0; i-- {
+		h = spawnMiddleware[i](h)
+	}
+	return h
+}

--- a/actor/props.go
+++ b/actor/props.go
@@ -179,7 +179,7 @@ func (props *Props) WithFunc(f ActorFunc) *Props {
 func (props *Props) WithSpawnMiddleware(middleware ...SpawnMiddleware) *Props {
 	props.spawnMiddleware = append(props.spawnMiddleware, middleware...)
 
-	// Construct the sender middleware chain with the final sender at the end
+	// Construct the spawner middleware chain with the final spawner at the end
 	props.spawnMiddlewareChain = makeSpawnMiddlewareChain(props.spawnMiddleware, func(id string, props *Props, parentContext SpawnerContext) (pid *PID, e error) {
 		if props.spawner == nil {
 			return defaultSpawner(id, props, parentContext)

--- a/actor/props.go
+++ b/actor/props.go
@@ -2,22 +2,22 @@ package actor
 
 import (
 	"errors"
-
 	"github.com/AsynkronIT/protoactor-go/mailbox"
 )
 
 // Props types
-type SpawnFunc func(id string, props *Props, parent *PID) (*PID, error)
+type SpawnFunc func(id string, props *Props, parentContext SpawnerContext) (*PID, error)
 type ReceiverMiddleware func(next ReceiverFunc) ReceiverFunc
 type SenderMiddleware func(next SenderFunc) SenderFunc
 type ContextDecorator func(next ContextDecoratorFunc) ContextDecoratorFunc
+type SpawnMiddleware func(next SpawnFunc) SpawnFunc
 
 // Default values
 var (
 	defaultDispatcher      = mailbox.NewDefaultDispatcher(300)
 	defaultMailboxProducer = mailbox.Unbounded()
-	defaultSpawner         = func(id string, props *Props, parent *PID) (*PID, error) {
-		ctx := newActorContext(props, parent)
+	defaultSpawner         = func(id string, props *Props, parentContext SpawnerContext) (*PID, error) {
+		ctx := newActorContext(props, parentContext.Self())
 		mb := props.produceMailbox()
 		dp := props.getDispatcher()
 		proc := NewActorProcess(mb)
@@ -53,8 +53,10 @@ type Props struct {
 	dispatcher              mailbox.Dispatcher
 	receiverMiddleware      []ReceiverMiddleware
 	senderMiddleware        []SenderMiddleware
+	spawnMiddleware         []SpawnMiddleware
 	receiverMiddlewareChain ReceiverFunc
 	senderMiddlewareChain   SenderFunc
+	spawnMiddlewareChain    SpawnFunc
 	contextDecorator        []ContextDecorator
 	contextDecoratorChain   ContextDecoratorFunc
 }
@@ -94,8 +96,8 @@ func (props *Props) produceMailbox() mailbox.Mailbox {
 	return props.mailboxProducer()
 }
 
-func (props *Props) spawn(name string, parent *PID) (*PID, error) {
-	return props.getSpawner()(name, props, parent)
+func (props *Props) spawn(name string, parentContext SpawnerContext) (*PID, error) {
+	return props.getSpawner()(name, props, parentContext)
 }
 
 // WithProducer assigns a actor producer to the props
@@ -171,6 +173,20 @@ func (props *Props) WithSpawnFunc(spawn SpawnFunc) *Props {
 // WithFunc assigns a receive func to the props
 func (props *Props) WithFunc(f ActorFunc) *Props {
 	props.producer = func() Actor { return f }
+	return props
+}
+
+func (props *Props) WithSpawnMiddleware(middleware ...SpawnMiddleware) *Props {
+	props.spawnMiddleware = append(props.spawnMiddleware, middleware...)
+
+	// Construct the sender middleware chain with the final sender at the end
+	props.spawnMiddlewareChain = makeSpawnMiddlewareChain(props.spawnMiddleware, func(id string, props *Props, parentContext SpawnerContext) (pid *PID, e error) {
+		if props.spawner == nil {
+			return defaultSpawner(id, props, parentContext)
+		}
+		return props.spawner(id, props, parentContext)
+	})
+
 	return props
 }
 

--- a/router/config.go
+++ b/router/config.go
@@ -51,12 +51,12 @@ func (config *PoolRouter) RouterType() RouterType {
 }
 
 func spawner(config RouterConfig) actor.SpawnFunc {
-	return func(id string, props *actor.Props, parent *actor.PID) (*actor.PID, error) {
-		return spawn(id, config, props, parent)
+	return func(id string, props *actor.Props, parentContext actor.SpawnerContext) (*actor.PID, error) {
+		return spawn(id, config, props, parentContext)
 	}
 }
 
-func spawn(id string, config RouterConfig, props *actor.Props, parent *actor.PID) (*actor.PID, error) {
+func spawn(id string, config RouterConfig, props *actor.Props, parentContext actor.SpawnerContext) (*actor.PID, error) {
 	ref := &process{}
 	proxy, absent := actor.ProcessRegistry.Add(ref, id)
 	if !absent {
@@ -77,7 +77,7 @@ func spawn(id string, config RouterConfig, props *actor.Props, parent *actor.PID
 				state:  ref.state,
 				wg:     wg,
 			}
-		}), parent)
+		}), parentContext)
 		wg.Wait() // wait for routerActor to start
 	} else {
 		wg := &sync.WaitGroup{}
@@ -89,7 +89,7 @@ func spawn(id string, config RouterConfig, props *actor.Props, parent *actor.PID
 				state:  ref.state,
 				wg:     wg,
 			}
-		}), parent)
+		}), parentContext)
 		wg.Wait() // wait for routerActor to start
 	}
 

--- a/router/config_test.go
+++ b/router/config_test.go
@@ -9,13 +9,14 @@ import (
 
 func TestSpawn(t *testing.T) {
 	pr := &broadcastPoolRouter{PoolRouter{PoolSize: 1}}
-	pid, err := spawn("foo", pr, actor.PropsFromFunc(func(context actor.Context) {}), nil)
+	pid, err := spawn("foo", pr, actor.PropsFromFunc(func(context actor.Context) {}), actor.EmptyRootContext())
 	assert.NoError(t, err)
 
 	_, exists := actor.ProcessRegistry.Get(actor.NewLocalPID("foo/router"))
 	assert.True(t, exists)
 
-	pid.StopFuture().Wait()
+	err = pid.StopFuture().Wait()
+	assert.NoError(t, err)
 
 	_, exists = actor.ProcessRegistry.Get(actor.NewLocalPID("foo/router"))
 	assert.False(t, exists)


### PR DESCRIPTION
I've been working on introducing OpenTracing Jaeger tracing to protoactor-go and one of the things that I found made it a lot easier is introducing a concept around SpawnMiddleware.
The SpawnMiddleware is triggered when an Actor (actually a Context) spawn a new child.

The Spawn middleware can be useful in many scenarios including propagation of other middleware, tracing and I'm sure much more.

I've also implemented a MiddlewarePropagator that supports getting middleware spread out
to full actor trees, with nothing but adding it to the root actor.