### PR TITLE
Add OpenTracing middleware

### DIFF
--- a/actor/actor_context.go
+++ b/actor/actor_context.go
@@ -358,7 +358,14 @@ func (ctx *actorContext) SpawnNamed(props *Props, name string) (*PID, error) {
 		panic(errors.New("Props used to spawn child cannot have GuardianStrategy"))
 	}
 
-	pid, err := props.spawn(ctx.self.Id+"/"+name, ctx.self)
+	var pid *PID
+	var err error
+	if ctx.props.spawnMiddlewareChain != nil {
+		pid, err = ctx.props.spawnMiddlewareChain(ctx.self.Id+"/"+name, props, ctx)
+	} else {
+		pid, err = props.spawn(ctx.self.Id+"/"+name, ctx)
+	}
+
 	if err != nil {
 		return pid, err
 	}

--- a/actor/actor_context_test.go
+++ b/actor/actor_context_test.go
@@ -15,13 +15,13 @@ func TestActorContext_SpawnNamed(t *testing.T) {
 	defer removeMockProcess(pid)
 
 	props := &Props{
-		spawner: func(id string, _ *Props, _ *PID) (*PID, error) {
+		spawner: func(id string, _ *Props, _ SpawnerContext) (*PID, error) {
 			assert.Equal(t, "foo/bar", id)
 			return NewLocalPID(id), nil
 		},
 	}
 
-	parent := &actorContext{self: NewLocalPID("foo")}
+	parent := &actorContext{self: NewLocalPID("foo"), props: props}
 	child, err := parent.SpawnNamed(props, "bar")
 	assert.NoError(t, err)
 	assert.Equal(t, parent.Children()[0], child)
@@ -204,7 +204,7 @@ func benchmarkActorContext_SpawnWithMiddlewareN(n int, b *testing.B) {
 		props = props.WithSenderMiddleware(middlwareFn)
 	}
 
-	parent := &actorContext{self: NewLocalPID("foo")}
+	parent := &actorContext{self: NewLocalPID("foo"), props: props}
 	for i := 0; i < b.N; i++ {
 		parent.Spawn(props)
 	}

--- a/actor/context.go
+++ b/actor/context.go
@@ -9,16 +9,19 @@ type Context interface {
 	senderPart
 	receiverPart
 	spawnerPart
+	messagePart
 }
 
 type SenderContext interface {
 	infoPart
 	senderPart
+	messagePart
 }
 
 type ReceiverContext interface {
 	infoPart
 	receiverPart
+	messagePart
 }
 
 type SpawnerContext interface {
@@ -72,15 +75,17 @@ type basePart interface {
 	AwaitFuture(f *Future, continuation func(res interface{}, err error))
 }
 
-type senderPart interface {
-	// Sender returns the PID of actor that sent currently processed message
-	Sender() *PID
-
+type messagePart interface {
 	// Message returns the current message to be processed
 	Message() interface{}
 
 	// MessageHeader returns the meta information for the currently processed message
 	MessageHeader() ReadonlyMessageHeader
+}
+
+type senderPart interface {
+	// Sender returns the PID of actor that sent currently processed message
+	Sender() *PID
 
 	// Send sends a message to the given PID
 	Send(pid *PID, message interface{})

--- a/actor/context.go
+++ b/actor/context.go
@@ -21,6 +21,11 @@ type ReceiverContext interface {
 	receiverPart
 }
 
+type SpawnerContext interface {
+	infoPart
+	spawnerPart
+}
+
 type infoPart interface {
 	// Parent returns the PID for the current actors parent
 	Parent() *PID

--- a/actor/middleware/opentracing/activespan.go
+++ b/actor/middleware/opentracing/activespan.go
@@ -1,0 +1,35 @@
+package opentracing
+
+import (
+	"fmt"
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/opentracing/opentracing-go"
+	"sync"
+)
+
+var activeSpan = sync.Map{}
+
+func getActiveSpan(pid *actor.PID) opentracing.Span {
+	value, ok := activeSpan.Load(pid)
+	if !ok {
+		return nil
+	}
+	return value.(opentracing.Span)
+}
+
+func clearActiveSpan(pid *actor.PID) {
+	activeSpan.Delete(pid)
+}
+
+func setActiveSpan(pid *actor.PID, span opentracing.Span) {
+	activeSpan.Store(pid, span)
+}
+
+func GetActiveSpan(context actor.Context) opentracing.Span {
+	span := getActiveSpan(context.Self())
+	if span == nil {
+		// TODO: Fix finding the real span always or handle no-span better on receiving side
+		span = opentracing.StartSpan(fmt.Sprintf("%T/%T", context.Actor(), context.Message()))
+	}
+	return span
+}

--- a/actor/middleware/opentracing/envelope.go
+++ b/actor/middleware/opentracing/envelope.go
@@ -1,0 +1,35 @@
+package opentracing
+
+import (
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/opentracing/opentracing-go"
+)
+
+type messageHeaderReader struct {
+	ReadOnlyMessageHeader actor.ReadonlyMessageHeader
+}
+
+func (reader *messageHeaderReader) ForeachKey(handler func(key, val string) error) error {
+	if reader.ReadOnlyMessageHeader == nil {
+		return nil
+	}
+	for _, key := range reader.ReadOnlyMessageHeader.Keys() {
+		err := handler(key, reader.ReadOnlyMessageHeader.Get(key))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var _ opentracing.TextMapReader = &messageHeaderReader{}
+
+type messageEnvelopeWriter struct {
+	MessageEnvelope *actor.MessageEnvelope
+}
+
+func (writer *messageEnvelopeWriter) Set(key, val string) {
+	writer.MessageEnvelope.SetHeader(key, val)
+}
+
+var _ opentracing.TextMapWriter = &messageEnvelopeWriter{}

--- a/actor/middleware/opentracing/logger.go
+++ b/actor/middleware/opentracing/logger.go
@@ -1,0 +1,5 @@
+package opentracing
+
+import "github.com/AsynkronIT/protoactor-go/log"
+
+var logger = log.New(log.ErrorLevel, "[TRACING]")

--- a/actor/middleware/opentracing/middlewarepropagation.go
+++ b/actor/middleware/opentracing/middlewarepropagation.go
@@ -1,0 +1,15 @@
+package opentracing
+
+import (
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/AsynkronIT/protoactor-go/actor/middleware/propagator"
+)
+
+func TracingMiddleware() actor.SpawnMiddleware {
+	return propagator.New().
+		WithItselfForwarded().
+		WithSpawnMiddleware(SpawnMiddleware()).
+		WithSenderMiddleware(SenderMiddleware()).
+		WithReceiverMiddleware(ReceiverMiddleware()).
+		SpawnMiddleware
+}

--- a/actor/middleware/opentracing/parentspan.go
+++ b/actor/middleware/opentracing/parentspan.go
@@ -1,0 +1,22 @@
+package opentracing
+
+import (
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/opentracing/opentracing-go"
+	"sync"
+)
+
+var parentSpans = sync.Map{}
+
+func getAndClearParentSpan(pid *actor.PID) opentracing.Span {
+	value, ok := parentSpans.Load(pid)
+	if !ok {
+		return nil
+	}
+	parentSpans.Delete(pid)
+	return value.(opentracing.Span)
+}
+
+func setParentSpan(pid *actor.PID, span opentracing.Span) {
+	parentSpans.Store(pid, span)
+}

--- a/actor/middleware/opentracing/receivermiddleware.go
+++ b/actor/middleware/opentracing/receivermiddleware.go
@@ -1,0 +1,81 @@
+package opentracing
+
+import (
+	"fmt"
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/AsynkronIT/protoactor-go/log"
+	"github.com/opentracing/opentracing-go"
+)
+
+func ReceiverMiddleware() actor.ReceiverMiddleware {
+	return func(next actor.ReceiverFunc) actor.ReceiverFunc {
+		return func(c actor.ReceiverContext, envelope *actor.MessageEnvelope) {
+			spanContext, err := opentracing.GlobalTracer().Extract(opentracing.TextMap, opentracing.TextMapReader(&messageHeaderReader{ReadOnlyMessageHeader: envelope.Header}))
+			if err == opentracing.ErrSpanContextNotFound {
+				logger.Debug("INBOUND No spanContext found", log.Stringer("PID", c.Self()), log.Error(err))
+				//next(c)
+			} else if err != nil {
+				logger.Debug("INBOUND Error", log.Stringer("PID", c.Self()), log.Error(err))
+				next(c, envelope)
+				return
+			}
+			var span opentracing.Span
+			switch envelope.Message.(type) {
+			case *actor.Started:
+				parentSpan := getAndClearParentSpan(c.Self())
+				if parentSpan != nil {
+					span = opentracing.StartSpan(fmt.Sprintf("%T/%T", c.Actor(), envelope.Message), opentracing.ChildOf(parentSpan.Context()))
+					logger.Debug("INBOUND Found parent span", log.Stringer("PID", c.Self()), log.TypeOf("ActorType", c.Actor()), log.TypeOf("MessageType", envelope.Message))
+				} else {
+					logger.Debug("INBOUND No parent span", log.Stringer("PID", c.Self()), log.TypeOf("ActorType", c.Actor()), log.TypeOf("MessageType", envelope.Message))
+				}
+			case *actor.Stopping:
+				var parentSpan opentracing.Span
+				if c.Parent() != nil {
+					parentSpan = getStoppingSpan(c.Parent())
+				}
+				if parentSpan != nil {
+					span = opentracing.StartSpan(fmt.Sprintf("%T/stopping", c.Actor()), opentracing.ChildOf(parentSpan.Context()))
+				} else {
+					span = opentracing.StartSpan(fmt.Sprintf("%T/stopping", c.Actor()))
+				}
+				setStoppingSpan(c.Self(), span)
+				span.SetTag("ActorPID", c.Self())
+				span.SetTag("ActorType", fmt.Sprintf("%T", c.Actor()))
+				span.SetTag("MessageType", fmt.Sprintf("%T", envelope.Message))
+				stoppingHandlingSpan := opentracing.StartSpan("stopping-handling", opentracing.ChildOf(span.Context()))
+				next(c, envelope)
+				stoppingHandlingSpan.Finish()
+				return
+			case *actor.Stopped:
+				span = getAndClearStoppingSpan(c.Self())
+				next(c, envelope)
+				if span != nil {
+					span.Finish()
+				}
+				return
+			}
+			if span == nil && spanContext == nil {
+				logger.Debug("INBOUND No spanContext. Starting new span", log.Stringer("PID", c.Self()), log.TypeOf("ActorType", c.Actor()), log.TypeOf("MessageType", envelope.Message))
+				span = opentracing.StartSpan(fmt.Sprintf("%T/%T", c.Actor(), envelope.Message))
+			}
+			if span == nil {
+				logger.Debug("INBOUND Starting span from parent", log.Stringer("PID", c.Self()), log.TypeOf("ActorType", c.Actor()), log.TypeOf("MessageType", envelope.Message))
+				span = opentracing.StartSpan(fmt.Sprintf("%T/%T", c.Actor(), envelope.Message), opentracing.ChildOf(spanContext))
+			}
+
+			setActiveSpan(c.Self(), span)
+			span.SetTag("ActorPID", c.Self())
+			span.SetTag("ActorType", fmt.Sprintf("%T", c.Actor()))
+			span.SetTag("MessageType", fmt.Sprintf("%T", envelope.Message))
+
+			defer func() {
+				logger.Debug("INBOUND Finishing span", log.Stringer("PID", c.Self()), log.TypeOf("ActorType", c.Actor()), log.TypeOf("MessageType", envelope.Message))
+				span.Finish()
+				clearActiveSpan(c.Self())
+			}()
+
+			next(c, envelope)
+		}
+	}
+}

--- a/actor/middleware/opentracing/sendermiddleware.go
+++ b/actor/middleware/opentracing/sendermiddleware.go
@@ -1,0 +1,33 @@
+package opentracing
+
+import (
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/AsynkronIT/protoactor-go/log"
+	"github.com/opentracing/opentracing-go"
+)
+
+func SenderMiddleware() actor.SenderMiddleware {
+
+	return func(next actor.SenderFunc) actor.SenderFunc {
+		return func(c actor.SenderContext, target *actor.PID, envelope *actor.MessageEnvelope) {
+
+			span := getActiveSpan(c.Self())
+
+			if span == nil {
+				logger.Debug("OUTBOUND No active span", log.Stringer("PID", c.Self()), log.TypeOf("ActorType", c.Actor()), log.TypeOf("MessageType", envelope.Message))
+				next(c, target, envelope)
+				return
+			}
+
+			err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.TextMap, opentracing.TextMapWriter(&messageEnvelopeWriter{MessageEnvelope: envelope}))
+			if err != nil {
+				logger.Debug("OUTBOUND Error injecting", log.Stringer("PID", c.Self()), log.TypeOf("ActorType", c.Actor()), log.TypeOf("MessageType", envelope.Message))
+				next(c, target, envelope)
+				return
+			}
+
+			logger.Debug("OUTBOUND Successfully injected", log.Stringer("PID", c.Self()), log.TypeOf("ActorType", c.Actor()), log.TypeOf("MessageType", envelope.Message))
+			next(c, target, envelope)
+		}
+	}
+}

--- a/actor/middleware/opentracing/spawnmiddleware.go
+++ b/actor/middleware/opentracing/spawnmiddleware.go
@@ -1,0 +1,33 @@
+package opentracing
+
+import (
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/AsynkronIT/protoactor-go/log"
+	olog "github.com/opentracing/opentracing-go/log"
+)
+
+func SpawnMiddleware() actor.SpawnMiddleware {
+	return func(next actor.SpawnFunc) actor.SpawnFunc {
+		return func(id string, props *actor.Props, parentContext actor.SpawnerContext) (pid *actor.PID, e error) {
+			self := parentContext.Self()
+			pid, err := next(id, props, parentContext)
+			if err != nil {
+				logger.Debug("SPAWN got error trying to spawn", log.Stringer("PID", self), log.TypeOf("ActorType", parentContext.Actor()), log.Error(err))
+				return pid, err
+			}
+			if self != nil {
+				span := getActiveSpan(self)
+				if span != nil {
+					setParentSpan(pid, span)
+					span.LogFields(olog.String("SpawnPID", pid.String()))
+					logger.Debug("SPAWN found active span", log.Stringer("PID", self), log.TypeOf("ActorType", parentContext.Actor()), log.Stringer("SpawnedPID", pid))
+				} else {
+					logger.Debug("SPAWN no active span on parent", log.Stringer("PID", self), log.TypeOf("ActorType", parentContext.Actor()), log.Stringer("SpawnedPID", pid))
+				}
+			} else {
+				logger.Debug("SPAWN no parent pid", log.Stringer("SpawnedPID", pid))
+			}
+			return pid, err
+		}
+	}
+}

--- a/actor/middleware/opentracing/stoppingspan.go
+++ b/actor/middleware/opentracing/stoppingspan.go
@@ -1,0 +1,30 @@
+package opentracing
+
+import (
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/opentracing/opentracing-go"
+	"sync"
+)
+
+var stoppingSpans = sync.Map{}
+
+func getAndClearStoppingSpan(pid *actor.PID) opentracing.Span {
+	value, ok := stoppingSpans.Load(pid)
+	if !ok {
+		return nil
+	}
+	stoppingSpans.Delete(pid)
+	return value.(opentracing.Span)
+}
+
+func getStoppingSpan(pid *actor.PID) opentracing.Span {
+	value, ok := stoppingSpans.Load(pid)
+	if !ok {
+		return nil
+	}
+	return value.(opentracing.Span)
+}
+
+func setStoppingSpan(pid *actor.PID, span opentracing.Span) {
+	stoppingSpans.Store(pid, span)
+}

--- a/actor/middleware/opentracing/tracing_test.go
+++ b/actor/middleware/opentracing/tracing_test.go
@@ -1,0 +1,1 @@
+package opentracing

--- a/actor/middleware/propagator/middlewarepropagation.go
+++ b/actor/middleware/propagator/middlewarepropagation.go
@@ -1,0 +1,59 @@
+package propagator
+
+import (
+	"github.com/AsynkronIT/protoactor-go/actor"
+)
+
+type MiddlewarePropagator struct {
+	spawnMiddleware    []actor.SpawnMiddleware
+	senderMiddleware   []actor.SenderMiddleware
+	receiverMiddleware []actor.ReceiverMiddleware
+	contextDecorators  []actor.ContextDecorator
+}
+
+func New() *MiddlewarePropagator {
+	return &MiddlewarePropagator{}
+}
+
+func (propagator *MiddlewarePropagator) WithItselfForwarded() *MiddlewarePropagator {
+	return propagator.WithSpawnMiddleware(propagator.SpawnMiddleware)
+}
+
+func (propagator *MiddlewarePropagator) WithSpawnMiddleware(middleware ...actor.SpawnMiddleware) *MiddlewarePropagator {
+	propagator.spawnMiddleware = append(propagator.spawnMiddleware, middleware...)
+	return propagator
+}
+
+func (propagator *MiddlewarePropagator) WithSenderMiddleware(middleware ...actor.SenderMiddleware) *MiddlewarePropagator {
+	propagator.senderMiddleware = append(propagator.senderMiddleware, middleware...)
+	return propagator
+}
+
+func (propagator *MiddlewarePropagator) WithReceiverMiddleware(middleware ...actor.ReceiverMiddleware) *MiddlewarePropagator {
+	propagator.receiverMiddleware = append(propagator.receiverMiddleware, middleware...)
+	return propagator
+}
+
+func (propagator *MiddlewarePropagator) WithContextDecorator(decorators ...actor.ContextDecorator) *MiddlewarePropagator {
+	propagator.contextDecorators = append(propagator.contextDecorators, decorators...)
+	return propagator
+}
+
+func (propagator *MiddlewarePropagator) SpawnMiddleware(next actor.SpawnFunc) actor.SpawnFunc {
+	return func(id string, props *actor.Props, parentContext actor.SpawnerContext) (pid *actor.PID, e error) {
+		if propagator.spawnMiddleware != nil {
+			props = props.WithSpawnMiddleware(propagator.spawnMiddleware...)
+		}
+		if propagator.senderMiddleware != nil {
+			props = props.WithSenderMiddleware(propagator.senderMiddleware...)
+		}
+		if propagator.receiverMiddleware != nil {
+			props = props.WithReceiverMiddleware(propagator.receiverMiddleware...)
+		}
+		if propagator.contextDecorators != nil {
+			props = props.WithContextDecorator(propagator.contextDecorators...)
+		}
+		pid, err := next(id, props, parentContext)
+		return pid, err
+	}
+}

--- a/actor/middleware/propagator/middlewarepropagation_test.go
+++ b/actor/middleware/propagator/middlewarepropagation_test.go
@@ -1,0 +1,43 @@
+package propagator
+
+import (
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+)
+
+func TestPropagator(t *testing.T) {
+
+	mutex := &sync.Mutex{}
+	spawningCounter := 0
+
+	propagator := New().
+		WithItselfForwarded().
+		WithSpawnMiddleware(func(next actor.SpawnFunc) actor.SpawnFunc {
+			return func(id string, props *actor.Props, parentContext actor.SpawnerContext) (pid *actor.PID, e error) {
+				mutex.Lock()
+				spawningCounter++
+				mutex.Unlock()
+				return next(id, props, parentContext)
+			}
+		})
+
+	var start func(input int) *actor.Props
+	start = func(input int) *actor.Props {
+		return actor.PropsFromFunc(func(c actor.Context) {
+			switch c.Message().(type) {
+			case *actor.Started:
+				if input > 0 {
+					c.Spawn(start(input - 1))
+				}
+			}
+		})
+	}
+
+	root := actor.NewRootContext(nil).WithSpawnMiddleware(propagator.SpawnMiddleware).Spawn(start(5))
+
+	root.StopFuture().Wait()
+
+	assert.Equal(t, 5, spawningCounter)
+}

--- a/actor/middleware/propagator/middlewarepropagation_test.go
+++ b/actor/middleware/propagator/middlewarepropagation_test.go
@@ -39,5 +39,5 @@ func TestPropagator(t *testing.T) {
 
 	root.StopFuture().Wait()
 
-	assert.Equal(t, 5, spawningCounter)
+	assert.Equal(t, spawningCounter, 5)
 }

--- a/actor/middleware_chain.go
+++ b/actor/middleware_chain.go
@@ -35,3 +35,15 @@ func makeContextDecoratorChain(decorator []ContextDecorator, lastDecorator Conte
 	}
 	return h
 }
+
+func makeSpawnMiddlewareChain(spawnMiddleware []SpawnMiddleware, lastSpawn SpawnFunc) SpawnFunc {
+	if len(spawnMiddleware) == 0 {
+		return nil
+	}
+
+	h := spawnMiddleware[len(spawnMiddleware)-1](lastSpawn)
+	for i := len(spawnMiddleware) - 2; i >= 0; i-- {
+		h = spawnMiddleware[i](h)
+	}
+	return h
+}

--- a/examples/jaegertracing/README.md
+++ b/examples/jaegertracing/README.md
@@ -1,0 +1,17 @@
+# Jeager Tracing / OpenTracing example
+
+To run the example an instance of Jaeger server is required running locally. The easiest way to run a jaeger server
+instance is starting it using the included docker-compose file like this
+
+```bash
+docker-compose -f ./examples/jaegertracing/docker-compose.yaml up -d
+``` 
+
+And the just run the example:
+
+```bash
+go run ./examples/jaegertracing/main.go
+```
+
+After the test has run (and also during), traces can found using the Jaeger UI started at http://localhost:16686.
+ 

--- a/examples/jaegertracing/docker-compose.yaml
+++ b/examples/jaegertracing/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.7
+    environment:
+      COLLECTOR_ZIPKIN_HTTP_PORT: 9411
+    ports:
+      - '5775:5775/udp'
+      - '6831:6831/udp'
+      - '6832:6832/udp'
+      - '5778:5778'
+      - '16686:16686'
+      - '14268:14268'
+      - '9411:9411'

--- a/examples/jaegertracing/main.go
+++ b/examples/jaegertracing/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"github.com/AsynkronIT/goconsole"
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/AsynkronIT/protoactor-go/actor/middleware/opentracing"
+	"github.com/uber/jaeger-client-go"
+	jaegercfg "github.com/uber/jaeger-client-go/config"
+	jaegerlog "github.com/uber/jaeger-client-go/log"
+	"github.com/uber/jaeger-lib/metrics"
+	"io"
+	"math/rand"
+	"time"
+)
+
+func main() {
+	jaegerCloser := initJaeger()
+	defer jaegerCloser.Close()
+
+	rootContext := actor.EmptyRootContext().WithSpawnMiddleware(opentracing.TracingMiddleware())
+
+	pid := rootContext.SpawnPrefix(createProps(5), "root")
+	for i := 0; i < 3; i++ {
+		rootContext.RequestFuture(pid, &request{i}, 10*time.Second).Wait()
+	}
+	console.ReadLine()
+}
+
+func initJaeger() io.Closer {
+	// Sample configuration for testing. Use constant sampling to sample every trace
+	// and enable LogSpan to log every span via configured Logger.
+	cfg := jaegercfg.Configuration{
+		Sampler: &jaegercfg.SamplerConfig{
+			Type:  jaeger.SamplerTypeConst,
+			Param: 1,
+		},
+		Reporter: &jaegercfg.ReporterConfig{
+			LogSpans: true,
+		},
+	}
+
+	// Example logger and metrics factory. Use github.com/uber/jaeger-client-go/log
+	// and github.com/uber/jaeger-lib/metrics respectively to bind to real logging and metrics
+	// frameworks.
+	jLogger := jaegerlog.StdLogger
+	jMetricsFactory := metrics.NullFactory
+
+	// Initialize tracer with a logger and a metrics factory
+	closer, err := cfg.InitGlobalTracer(
+		"jaeger-test",
+		jaegercfg.Logger(jLogger),
+		jaegercfg.Metrics(jMetricsFactory),
+	)
+	if err != nil {
+		//log.Printf("Could not initialize jaeger tracer: %s", err.Error())
+		panic(fmt.Sprintf("Could not initialize jaeger tracer: %s", err.Error()))
+	}
+	return closer
+}
+
+func createProps(levels int) *actor.Props {
+	if levels <= 1 {
+		sleep := time.Duration(rand.Intn(5000))
+
+		return actor.PropsFromFunc(func(c actor.Context) {
+			switch msg := c.Message().(type) {
+			case *request:
+				time.Sleep(sleep * time.Millisecond)
+				if c.Sender() != nil {
+					c.Respond(&response{i: msg.i})
+				}
+			}
+		})
+	}
+
+	var childs []*actor.PID
+	return actor.PropsFromFunc(func(c actor.Context) {
+		switch c.Message().(type) {
+		case *actor.Started:
+			for i := 0; i < 3; i++ {
+				childs = append(childs, c.Spawn(createProps(levels-1)))
+			}
+		case *request:
+			c.Forward(childs[rand.Intn(len(childs))])
+		}
+	})
+}
+
+type request struct {
+	i int
+}
+
+type response struct {
+	i int
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/AsynkronIT/gonet v0.0.0-20161127091928-0553637be225
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/couchbase/gocb v1.5.2 // indirect
 	github.com/emirpasic/gods v1.12.0
 	github.com/gogo/protobuf v1.2.1
@@ -17,9 +18,13 @@ require (
 	github.com/hashicorp/go-rootcerts v1.0.0 // indirect
 	github.com/hashicorp/serf v0.8.2 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
-	github.com/opentracing/opentracing-go v1.0.2 // indirect
+	github.com/opentracing/opentracing-go v1.0.2
 	github.com/orcaman/concurrent-map v0.0.0-20190107190726-7ed82d9cb717
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/serialx/hashring v0.0.0-20180504054112-49a4782e9908
+	github.com/stretchr/testify v1.3.0
+	github.com/uber/jaeger-client-go v2.15.0+incompatible
+	github.com/uber/jaeger-lib v1.5.0
 	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd
 	google.golang.org/grpc v1.18.0
 	gopkg.in/couchbase/gocbcore.v7 v7.1.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
+github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/couchbase/gocb v1.5.2 h1:8c0X+y/B4EqbGh0HE/XM+NB3HGUr2FD+XcHXpqUPV6c=
 github.com/couchbase/gocb v1.5.2/go.mod h1:AtRhXLpjgHmkRgG3e0K9t41qnWFonb8iohS/u/TZzxM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -82,6 +84,8 @@ github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/orcaman/concurrent-map v0.0.0-20190107190726-7ed82d9cb717 h1:2v7IYkog9ZFN04bv5hkwjpyHkc6wujPPOVYDPp2rfwA=
 github.com/orcaman/concurrent-map v0.0.0-20190107190726-7ed82d9cb717/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -90,10 +94,17 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUt
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/serialx/hashring v0.0.0-20180504054112-49a4782e9908 h1:RRpyb4kheanCQVyYfOhkZoD/cwClvn12RzHex2ZmHxw=
 github.com/serialx/hashring v0.0.0-20180504054112-49a4782e9908/go.mod h1:/yeG0My1xr/u+HZrFQ1tOQQQQrOawfyMUH13ai5brBc=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/uber/jaeger-client-go v2.15.0+incompatible h1:NP3qsSqNxh8VYr956ur1N/1C1PjvOJnJykCzcD5QHbk=
+github.com/uber/jaeger-client-go v2.15.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-lib v1.5.0 h1:OHbgr8l656Ub3Fw5k9SWnBfIEwvoHQ+W2y+Aa9D1Uyo=
+github.com/uber/jaeger-lib v1.5.0/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
+github.com/uber/jaeger-lib v2.0.0+incompatible h1:iMSCV0rmXEogjNWPh2D0xk9YVKvrtGoHJNe9ebLu/pw=
+github.com/uber/jaeger-lib v2.0.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3 h1:KYQXGkl6vs02hK7pK4eIbw0NpNPedieTSTEiJ//bwGs=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 h1:x/bBzNauLQAlE3fLku/xy92Y8QwKX5HZymrMz2IiKFc=

--- a/router/config.go
+++ b/router/config.go
@@ -93,6 +93,6 @@ func spawn(id string, config RouterConfig, props *actor.Props, parentContext act
 		wg.Wait() // wait for routerActor to start
 	}
 
-	ref.parent = parent
+	ref.parent = parentContext.Self()
 	return proxy, nil
 }

--- a/router/config.go
+++ b/router/config.go
@@ -51,12 +51,12 @@ func (config *PoolRouter) RouterType() RouterType {
 }
 
 func spawner(config RouterConfig) actor.SpawnFunc {
-	return func(id string, props *actor.Props, parent *actor.PID) (*actor.PID, error) {
-		return spawn(id, config, props, parent)
+	return func(id string, props *actor.Props, parentContext actor.SpawnerContext) (*actor.PID, error) {
+		return spawn(id, config, props, parentContext)
 	}
 }
 
-func spawn(id string, config RouterConfig, props *actor.Props, parent *actor.PID) (*actor.PID, error) {
+func spawn(id string, config RouterConfig, props *actor.Props, parentContext actor.SpawnerContext) (*actor.PID, error) {
 	ref := &process{}
 	proxy, absent := actor.ProcessRegistry.Add(ref, id)
 	if !absent {
@@ -77,7 +77,7 @@ func spawn(id string, config RouterConfig, props *actor.Props, parent *actor.PID
 				state:  ref.state,
 				wg:     wg,
 			}
-		}), parent)
+		}), parentContext)
 		wg.Wait() // wait for routerActor to start
 	} else {
 		wg := &sync.WaitGroup{}
@@ -89,7 +89,7 @@ func spawn(id string, config RouterConfig, props *actor.Props, parent *actor.PID
 				state:  ref.state,
 				wg:     wg,
 			}
-		}), parent)
+		}), parentContext)
 		wg.Wait() // wait for routerActor to start
 	}
 

--- a/router/config_test.go
+++ b/router/config_test.go
@@ -9,13 +9,14 @@ import (
 
 func TestSpawn(t *testing.T) {
 	pr := &broadcastPoolRouter{PoolRouter{PoolSize: 1}}
-	pid, err := spawn("foo", pr, actor.PropsFromFunc(func(context actor.Context) {}), nil)
+	pid, err := spawn("foo", pr, actor.PropsFromFunc(func(context actor.Context) {}), actor.EmptyRootContext)
 	assert.NoError(t, err)
 
 	_, exists := actor.ProcessRegistry.Get(actor.NewLocalPID("foo/router"))
 	assert.True(t, exists)
 
-	pid.StopFuture().Wait()
+	err = pid.StopFuture().Wait()
+	assert.NoError(t, err)
 
 	_, exists = actor.ProcessRegistry.Get(actor.NewLocalPID("foo/router"))
 	assert.False(t, exists)


### PR DESCRIPTION
This PR is adding my proposal for doing OpenTracing in a useful and only a bit opinionated manner.

The code doesn't setup or use jaeger, since it isn't a requirement, but it works great with jaeger. I've tested it with [jaeger-client-go](https://github.com/jaegertracing/jaeger-client-go).

Will add some tests in upcoming commits

This implementation use a few sync maps to store local defined opentracing
span's across several function scopes.
A nicer solution would be appreciated, but looking to the dotnet counterpart
the same behavior is implemented using thread static variables which isn't
an option in go.