### PR TITLE
Revise default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ func (state *HelloActor) Receive(context actor.Context) {
 }
 
 func main() {
-    context := actor.EmptyRootContext()
+    context := actor.EmptyRootContext
     props := actor.PropsFromProducer(func() actor.Actor { return &HelloActor{} })
     pid, err := context.Spawn(props)
     if err != nil {
@@ -169,7 +169,7 @@ func NewSetBehaviorActor() actor.Actor {
 }
 
 func main() {
-    context := actor.EmptyRootContext()
+    context := actor.EmptyRootContext
     props := actor.PropsFromProducer(NewSetBehaviorActor)
     pid, err := context.Spawn(props)
     if err != nil {
@@ -205,7 +205,7 @@ func (state *HelloActor) Receive(context actor.Context) {
 }
 
 func main() {
-    context := actor.EmptyRootContext()
+    context := actor.EmptyRootContext
     props := actor.PropsFromProducer(func() actor.Actor { return &HelloActor{} })
     pid, err := context.Spawn(props)
     if err != nil {
@@ -278,7 +278,7 @@ func main() {
     }
     supervisor := actor.NewOneForOneStrategy(10, 1000, decider)
 
-    context := actor.EmptyRootContext()
+    context := actor.EmptyRootContext
     props := actor.
         FromProducer(NewParentActor).
         WithSupervisor(supervisor)
@@ -317,7 +317,7 @@ func (state *MyActor) Receive(context actor.Context) {
 func main() {
     remote.Start("localhost:8090")
 
-    rootCtx := actor.EmptyRootContext()
+    rootCtx := actor.EmptyRootContext
     props := actor.PropsFromProducer(func() actor.Actor { return &MyActor{} })
     pid, _ := rootCtx.Spawn(props)
     message := &messages.Echo{Message: "hej", Sender: pid}

--- a/actor/actor_example_test.go
+++ b/actor/actor_example_test.go
@@ -10,7 +10,7 @@ import (
 
 // Demonstrates how to create an actor using a function literal and how to send a message asynchronously
 func Example() {
-	var context *actor.RootContext = actor.EmptyRootContext()
+	var context *actor.RootContext = actor.EmptyRootContext
 	var props *actor.Props = actor.PropsFromFunc(func(c actor.Context) {
 		if msg, ok := c.Message().(string); ok {
 			fmt.Println(msg) // outputs "Hello World"
@@ -33,7 +33,7 @@ func Example_synchronous() {
 	wg.Add(1)
 
 	// callee will wait for the PING message
-	callee := actor.EmptyRootContext().Spawn(actor.PropsFromFunc(func(c actor.Context) {
+	callee := actor.EmptyRootContext.Spawn(actor.PropsFromFunc(func(c actor.Context) {
 		if msg, ok := c.Message().(string); ok {
 			fmt.Println(msg) // outputs PING
 			c.Respond("PONG")
@@ -41,7 +41,7 @@ func Example_synchronous() {
 	}))
 
 	// caller will send a PING message and wait for the PONG
-	caller := actor.EmptyRootContext().Spawn(actor.PropsFromFunc(func(c actor.Context) {
+	caller := actor.EmptyRootContext.Spawn(actor.PropsFromFunc(func(c actor.Context) {
 		switch msg := c.Message().(type) {
 		// the first message an actor receives after it has started
 		case *actor.Started:

--- a/actor/common_test.go
+++ b/actor/common_test.go
@@ -10,7 +10,7 @@ import (
 var nullProducer Producer = func() Actor { return nullReceive }
 var nullReceive ActorFunc = func(Context) {}
 var nilPID *PID
-var rootContext = EmptyRootContext()
+var rootContext = EmptyRootContext
 
 func matchPID(with *PID) interface{} {
 	return mock.MatchedBy(func(v *PID) bool {

--- a/actor/context_example_setReceiveTimeout_test.go
+++ b/actor/context_example_setReceiveTimeout_test.go
@@ -33,7 +33,7 @@ func ExampleContext_setReceiveTimeout() {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	pid := actor.EmptyRootContext().Spawn(actor.PropsFromProducer(func() actor.Actor { return &setReceiveTimeoutActor{wg} }))
+	pid := actor.EmptyRootContext.Spawn(actor.PropsFromProducer(func() actor.Actor { return &setReceiveTimeoutActor{wg} }))
 	defer pid.GracefulStop()
 
 	wg.Wait() // wait for the ReceiveTimeout message

--- a/actor/future_example_test.go
+++ b/actor/future_example_test.go
@@ -13,7 +13,7 @@ func ExampleFuture_PipeTo() {
 	wg.Add(1)
 
 	// test actor that will be the target of the future PipeTo
-	pid := actor.EmptyRootContext().Spawn(actor.PropsFromFunc(func(ctx actor.Context) {
+	pid := actor.EmptyRootContext.Spawn(actor.PropsFromFunc(func(ctx actor.Context) {
 		// check if the message is a string and therefore
 		// the "hello world" message piped from the future
 		if m, ok := ctx.Message().(string); ok {
@@ -25,7 +25,7 @@ func ExampleFuture_PipeTo() {
 	f := actor.NewFuture(50 * time.Millisecond)
 	f.PipeTo(pid)
 	// resolve the future and pipe to waiting actor
-	actor.EmptyRootContext().Send(f.PID(), "hello world")
+	actor.EmptyRootContext.Send(f.PID(), "hello world")
 	wg.Wait()
 
 	// Output: hello world

--- a/actor/message_envelope.go
+++ b/actor/message_envelope.go
@@ -58,7 +58,7 @@ func (me *MessageEnvelope) SetHeader(key string, value string) {
 }
 
 var (
-	emptyMessageHeader = make(messageHeader)
+	EmptyMessageHeader = make(messageHeader)
 )
 
 func WrapEnvelope(message interface{}) *MessageEnvelope {

--- a/actor/pid.go
+++ b/actor/pid.go
@@ -132,18 +132,18 @@ func pidFromKey(key string, p *PID) {
 
 // Deprecated: Use Context.Send instead
 func (pid *PID) Tell(message interface{}) {
-	ctx := EmptyRootContext()
+	ctx := EmptyRootContext
 	ctx.Send(pid, message)
 }
 
 // Deprecated: Use Context.Request or Context.RequestWithCustomSender instead
 func (pid *PID) Request(message interface{}, respondTo *PID) {
-	ctx := EmptyRootContext()
+	ctx := EmptyRootContext
 	ctx.RequestWithCustomSender(pid, message, respondTo)
 }
 
 // Deprecated: Use Context.RequestFuture instead
 func (pid *PID) RequestFuture(message interface{}, timeout time.Duration) *Future {
-	ctx := EmptyRootContext()
+	ctx := EmptyRootContext
 	return ctx.RequestFuture(pid, message, timeout)
 }

--- a/actor/root_context.go
+++ b/actor/root_context.go
@@ -9,7 +9,7 @@ type RootContext struct {
 
 var emptyRootContext = &RootContext{
 	senderMiddleware: nil,
-	headers:          emptyMessageHeader,
+	headers:          EmptyMessageHeader,
 }
 
 func EmptyRootContext() *RootContext {

--- a/actor/root_context.go
+++ b/actor/root_context.go
@@ -2,20 +2,20 @@ package actor
 
 import "time"
 
+// RootContext a Context can be used outside of Actor
 type RootContext struct {
 	senderMiddleware SenderFunc
 	headers          messageHeader
 }
 
-var emptyRootContext = &RootContext{
+// EmptyRootContext returns the default RootContext.
+// Please do not set any headers/middlewares to this context.
+var EmptyRootContext = &RootContext{
 	senderMiddleware: nil,
 	headers:          EmptyMessageHeader,
 }
 
-func EmptyRootContext() *RootContext {
-	return emptyRootContext
-}
-
+// NewRootContext creates a new RootContext that can be customized with headers and middlewares.
 func NewRootContext(header map[string]string, middleware ...SenderMiddleware) *RootContext {
 	return &RootContext{
 		senderMiddleware: makeSenderMiddlewareChain(middleware, func(_ SenderContext, target *PID, envelope *MessageEnvelope) {
@@ -25,11 +25,13 @@ func NewRootContext(header map[string]string, middleware ...SenderMiddleware) *R
 	}
 }
 
+// WithHeaders set headers to RootContext.
 func (rc *RootContext) WithHeaders(headers map[string]string) *RootContext {
 	rc.headers = headers
 	return rc
 }
 
+// WithSenderMiddleware set SenderMiddlewares to RootContext.
 func (rc *RootContext) WithSenderMiddleware(middleware ...SenderMiddleware) *RootContext {
 	rc.senderMiddleware = makeSenderMiddlewareChain(middleware, func(_ SenderContext, target *PID, envelope *MessageEnvelope) {
 		target.sendUserMessage(envelope)

--- a/actor/spawn.go
+++ b/actor/spawn.go
@@ -3,13 +3,13 @@ package actor
 // Spawn starts a new actor based on props and named with a unique id
 // Deprecated: Use context.Spawn instead.
 func Spawn(props *Props) *PID {
-	return EmptyRootContext().Spawn(props)
+	return EmptyRootContext.Spawn(props)
 }
 
 // SpawnPrefix starts a new actor based on props and named using a prefix followed by a unique id
 // Deprecated: Use context.SpawnPrefix instead.
 func SpawnPrefix(props *Props, prefix string) *PID {
-	return EmptyRootContext().SpawnPrefix(props, prefix)
+	return EmptyRootContext.SpawnPrefix(props, prefix)
 }
 
 // SpawnNamed starts a new actor based on props and named using the specified name
@@ -17,6 +17,6 @@ func SpawnPrefix(props *Props, prefix string) *PID {
 // If name exists, error will be ErrNameExists
 // Deprecated: Use context.SpawnNamed instead.
 func SpawnNamed(props *Props, name string) (*PID, error) {
-	context := EmptyRootContext()
+	context := EmptyRootContext
 	return context.SpawnNamed(props, name)
 }

--- a/actor/spawn_example_test.go
+++ b/actor/spawn_example_test.go
@@ -13,7 +13,7 @@ func ExampleSpawn() {
 	wg.Add(1)
 
 	// create root context
-	context := actor.EmptyRootContext()
+	context := actor.EmptyRootContext
 
 	// define the actor props
 	// props define the creation process of an actor

--- a/actor/spawn_named_example_test.go
+++ b/actor/spawn_named_example_test.go
@@ -14,7 +14,7 @@ func ExampleSpawnNamed() {
 	wg.Add(1)
 
 	// create root context
-	context := actor.EmptyRootContext()
+	context := actor.EmptyRootContext
 
 	// define the actor props
 	// props define the creation process of an actor

--- a/cli/main.go
+++ b/cli/main.go
@@ -39,7 +39,7 @@ func filterInput(r rune) (rune, bool) {
 }
 
 var echoPID *actor.PID
-var rootContext = actor.EmptyRootContext()
+var rootContext = actor.EmptyRootContext
 
 func main() {
 	logo := `

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -11,7 +11,7 @@ import (
 
 var cfg *ClusterConfig
 
-var rootContext *actor.RootContext = actor.EmptyRootContext()
+var rootContext *actor.RootContext = actor.EmptyRootContext
 
 func Start(clusterName, address string, provider ClusterProvider) {
 	StartWithConfig(NewClusterConfig(clusterName, address, provider))

--- a/examples/backpressure/main.go
+++ b/examples/backpressure/main.go
@@ -89,7 +89,7 @@ type work struct {
 var context *actor.RootContext
 
 func main() {
-	context := actor.EmptyRootContext()
+	context := actor.EmptyRootContext
 	producerProps := actor.PropsFromProducer(func() actor.Actor { return &producer{} })
 	context.Spawn(producerProps)
 

--- a/examples/chat/client/main.go
+++ b/examples/chat/client/main.go
@@ -15,7 +15,7 @@ func main() {
 	server := actor.NewPID("127.0.0.1:8080", "chatserver")
 
 	// define root context
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 
 	// spawn our chat client inline
 	props := actor.PropsFromFunc(func(context actor.Context) {

--- a/examples/chat/server/main.go
+++ b/examples/chat/server/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 // define root context
-var rootContext = actor.EmptyRootContext()
+var rootContext = actor.EmptyRootContext
 
 func notifyAll(clients *hashset.Set, message interface{}) {
 	for _, tmp := range clients.Values() {

--- a/examples/cluster-metrics/shared/protos_protoactor.go
+++ b/examples/cluster-metrics/shared/protos_protoactor.go
@@ -19,7 +19,7 @@ var _ = math.Inf
 	
 var xHelloFactory func() Hello
 
-var rootContext = actor.EmptyRootContext()
+var rootContext = actor.EmptyRootContext
 
 func HelloFactory(factory func() Hello) {
 	xHelloFactory = factory

--- a/examples/cluster/shared/protos_protoactor.go
+++ b/examples/cluster/shared/protos_protoactor.go
@@ -19,7 +19,7 @@ var _ = math.Inf
 	
 var xHelloFactory func() Hello
 
-var rootContext = actor.EmptyRootContext()
+var rootContext = actor.EmptyRootContext
 
 func HelloFactory(factory func() Hello) {
 	xHelloFactory = factory

--- a/examples/distributedchannels/node1/main.go
+++ b/examples/distributedchannels/node1/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 // define root context
-var rootContext = actor.EmptyRootContext()
+var rootContext = actor.EmptyRootContext
 
 func newMyMessageSenderChannel() chan<- *messages.MyMessage {
 	channel := make(chan *messages.MyMessage)

--- a/examples/distributedchannels/node2/main.go
+++ b/examples/distributedchannels/node2/main.go
@@ -24,7 +24,7 @@ func main() {
 	})
 
 	// define root context
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 
 	// spawn
 	rootContext.SpawnNamed(props, "MyMessage")

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -19,7 +19,7 @@ func (state *helloActor) Receive(context actor.Context) {
 
 func main() {
 	props := actor.PropsFromProducer(func() actor.Actor { return &helloActor{} })
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	pid := rootContext.Spawn(props)
 	rootContext.Send(pid, &hello{Who: "Roger"})
 	console.ReadLine()

--- a/examples/inprocessbenchmark/main.go
+++ b/examples/inprocessbenchmark/main.go
@@ -121,7 +121,7 @@ func main() {
 			PropsFromProducer(newPingActor(&wg, messageCount, batchSize)).
 			WithMailbox(mailbox.Bounded(batchSize + 10)).
 			WithDispatcher(d)
-		rootContext := actor.EmptyRootContext()
+		rootContext := actor.EmptyRootContext
 
 		echoProps := actor.
 			PropsFromFunc(

--- a/examples/lifecycleevents/main.go
+++ b/examples/lifecycleevents/main.go
@@ -27,7 +27,7 @@ func (state *helloActor) Receive(context actor.Context) {
 }
 
 func main() {
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.PropsFromProducer(func() actor.Actor { return &helloActor{} })
 	pid := rootContext.Spawn(props)
 	rootContext.Send(pid, &hello{Who: "Roger"})

--- a/examples/limitconcurrency/main.go
+++ b/examples/limitconcurrency/main.go
@@ -20,7 +20,7 @@ func doWork(ctx actor.Context) {
 }
 
 func main() {
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	pid := rootContext.Spawn(router.NewRoundRobinPool(maxConcurrency).WithFunc(doWork))
 	for i := 0; i < 1000; i++ {
 		rootContext.Send(pid, &workItem{i})

--- a/examples/mailboxstats/main.go
+++ b/examples/mailboxstats/main.go
@@ -24,7 +24,7 @@ func (m *mailboxLogger) MailboxEmpty() {
 }
 
 func main() {
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.PropsFromFunc(func(ctx actor.Context) {
 
 	}).WithMailbox(mailbox.Unbounded(&mailboxLogger{}))

--- a/examples/mixins/main.go
+++ b/examples/mixins/main.go
@@ -43,7 +43,7 @@ func (p *NamerPlugin) OnStart(ctx actor.ReceiverContext) {
 func (p *NamerPlugin) OnOtherMessage(ctx actor.ReceiverContext, env *actor.MessageEnvelope) {}
 
 func main() {
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.
 		PropsFromProducer(func() actor.Actor { return &myActor{} }).
 		WithReceiverMiddleware(

--- a/examples/persistence/main.go
+++ b/examples/persistence/main.go
@@ -80,7 +80,7 @@ func main() {
 	provider := NewProvider(3)
 	provider.InitState("persistent", 4, 3)
 
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.PropsFromProducer(func() actor.Actor { return &Actor{} }).WithReceiverMiddleware(persistence.Using(provider))
 	pid, _ := rootContext.SpawnNamed(props, "persistent")
 	rootContext.Send(pid, &Message{protoMsg: protoMsg{state: "state4"}})

--- a/examples/receivepipeline/main.go
+++ b/examples/receivepipeline/main.go
@@ -18,7 +18,7 @@ func receive(context actor.Context) {
 }
 
 func main() {
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.PropsFromFunc(receive).WithReceiverMiddleware(middleware.Logger)
 	pid := rootContext.Spawn(props)
 	rootContext.Send(pid, &hello{Who: "Roger"})

--- a/examples/receivetimeout/main.go
+++ b/examples/receivetimeout/main.go
@@ -19,7 +19,7 @@ func main() {
 
 	c := 0
 
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.PropsFromFunc(func(context actor.Context) {
 		switch msg := context.Message().(type) {
 		case *actor.Started:

--- a/examples/remoteactivate/node1/main.go
+++ b/examples/remoteactivate/node1/main.go
@@ -15,7 +15,7 @@ func main() {
 	remote.Start("127.0.0.1:8081")
 	pidResp, _ := remote.SpawnNamed("127.0.0.1:8080", "remote", "hello", timeout)
 	pid := pidResp.Pid
-	res, _ := actor.EmptyRootContext().RequestFuture(pid, &messages.HelloRequest{}, timeout).Result()
+	res, _ := actor.EmptyRootContext.RequestFuture(pid, &messages.HelloRequest{}, timeout).Result()
 	response := res.(*messages.HelloResponse)
 	fmt.Printf("Response from remote %v", response.Message)
 

--- a/examples/remotebenchmark/node1/main.go
+++ b/examples/remotebenchmark/node1/main.go
@@ -81,7 +81,7 @@ func main() {
 	// remote.DefaultSerializerID = 1
 	remote.Start("127.0.0.1:8081")
 
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.
 		PropsFromProducer(newLocalActor(&wg, messageCount)).
 		WithMailbox(mailbox.Bounded(1000000))

--- a/examples/remotebenchmark/node2/main.go
+++ b/examples/remotebenchmark/node2/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	remote.Start("127.0.0.1:8080")
 	var sender *actor.PID
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.
 		PropsFromFunc(
 			func(context actor.Context) {

--- a/examples/remoteheader/node1/main.go
+++ b/examples/remoteheader/node1/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	remote.Start("127.0.0.1:8081")
 
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.
 		PropsFromFunc(func(context actor.Context) {
 			switch context.Message().(type) {

--- a/examples/remoteheader/node2/main.go
+++ b/examples/remoteheader/node2/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	remote.Start("127.0.0.1:8080")
 	var sender *actor.PID
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.
 		PropsFromFunc(
 			func(context actor.Context) {

--- a/examples/remotelatency/node1/main.go
+++ b/examples/remotelatency/node1/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	remote.Start("127.0.0.1:8081", remote.WithEndpointWriterBatchSize(10000))
 
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 
 	remote := actor.NewPID("127.0.0.1:8080", "remote")
 	rootContext.RequestFuture(remote, &messages.Start{}, 5*time.Second).

--- a/examples/remotelatency/node2/main.go
+++ b/examples/remotelatency/node2/main.go
@@ -84,7 +84,7 @@ func main() {
 	runtime.GC()
 
 	remote.Start("127.0.0.1:8080", remote.WithEndpointWriterBatchSize(10000))
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.
 		PropsFromProducer(newRemoteActor()).
 		WithMailbox(mailbox.Bounded(1000))

--- a/examples/remoterouting/client/main.go
+++ b/examples/remoterouting/client/main.go
@@ -24,7 +24,7 @@ func main() {
 	p1 := actor.NewPID("127.0.0.1:8101", "remote")
 	p2 := actor.NewPID("127.0.0.1:8102", "remote")
 
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 
 	remotePID := rootContext.Spawn(router.NewConsistentHashGroup(p1, p2))
 

--- a/examples/remoterouting/server/main.go
+++ b/examples/remoterouting/server/main.go
@@ -41,7 +41,7 @@ func newRemoteActor(name string) actor.Producer {
 func newRemote(bind, name string) {
 	remote.Start(bind)
 
-	context := actor.EmptyRootContext()
+	context := actor.EmptyRootContext
 	props := actor.
 		PropsFromProducer(newRemoteActor(name)).
 		WithMailbox(mailbox.Bounded(10000))

--- a/examples/remotessl/nodes/node1/main.go
+++ b/examples/remotessl/nodes/node1/main.go
@@ -42,7 +42,7 @@ func main() {
 	remote.Start("localhost:8090", sslDialOption, sslServerOption)
 
 	// start the local actor which looks for SYN messages from node2
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.PropsFromProducer(func() actor.Actor { return &node1Actor{} })
 	_, err = rootContext.SpawnNamed(props, "node1")
 	if err != nil {

--- a/examples/remotessl/nodes/node2/main.go
+++ b/examples/remotessl/nodes/node2/main.go
@@ -41,7 +41,7 @@ func main() {
 	remote.Start("localhost:8091", sslDialOption, sslServerOption)
 
 	// start the local actor which looks for ACK messages from node1
-	context := actor.EmptyRootContext()
+	context := actor.EmptyRootContext
 	props := actor.PropsFromProducer(func() actor.Actor { return &node2Actor{} })
 	pid, err := context.SpawnNamed(props, "node2")
 	if err != nil {

--- a/examples/remotewatch/node1/main.go
+++ b/examples/remotewatch/node1/main.go
@@ -13,7 +13,7 @@ func main() {
 	timeout := 5 * time.Second
 	remote.Start("127.0.0.1:8081")
 
-	context := actor.EmptyRootContext()
+	context := actor.EmptyRootContext
 	props := actor.PropsFromFunc(func(ctx actor.Context) {
 		switch msg := ctx.Message().(type) {
 		case *actor.Started:

--- a/examples/requestresponse/main.go
+++ b/examples/requestresponse/main.go
@@ -18,7 +18,7 @@ func Receive(context actor.Context) {
 }
 
 func main() {
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.PropsFromFunc(Receive)
 	pid := rootContext.Spawn(props)
 	result, _ := rootContext.RequestFuture(pid, Hello{Who: "Roger"}, 30*time.Second).Result() // await result

--- a/examples/routing/main.go
+++ b/examples/routing/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	log.Println("Round robin routing:")
 
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	act := func(context actor.Context) {
 		switch msg := context.Message().(type) {
 		case *myMessage:

--- a/examples/setbehavior/README.MD
+++ b/examples/setbehavior/README.MD
@@ -56,7 +56,7 @@ func NewSetBehaviorActor() actor.Actor {
 }
 
 func main() {
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.PropsFromProducer(NewSetBehaviorActor)
 	pid, _ := rootContext.Spawn(props)
 	rootContext.Send(pid, Hello{Who: "Roger"})

--- a/examples/setbehavior/main.go
+++ b/examples/setbehavior/main.go
@@ -40,7 +40,7 @@ func NewSetBehaviorActor() actor.Actor {
 }
 
 func main() {
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.PropsFromProducer(NewSetBehaviorActor)
 	pid := rootContext.Spawn(props)
 	rootContext.Send(pid, Hello{Who: "Roger"})

--- a/examples/spawnbenchmark/main.go
+++ b/examples/spawnbenchmark/main.go
@@ -76,7 +76,7 @@ func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	runtime.GC()
 
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 
 	start := time.Now()
 	pid := rootContext.Spawn(props)

--- a/examples/supervision/main.go
+++ b/examples/supervision/main.go
@@ -51,7 +51,7 @@ func main() {
 		return actor.StopDirective
 	}
 	supervisor := actor.NewOneForOneStrategy(10, 1000, decider)
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.
 		PropsFromProducer(newParentActor).
 		WithSupervisor(supervisor)

--- a/persistence/plugin_test.go
+++ b/persistence/plugin_test.go
@@ -127,7 +127,7 @@ func TestRecovery(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
-			rootContext := actor.EmptyRootContext()
+			rootContext := actor.EmptyRootContext
 			props := actor.PropsFromProducer(makeActor).
 				WithReceiverMiddleware(Using(tc.init))
 			pid, err := rootContext.SpawnNamed(props, ActorName)

--- a/plugin/passivation_test.go
+++ b/plugin/passivation_test.go
@@ -24,7 +24,7 @@ func TestPassivation(t *testing.T) {
 
 	UnitOfTime := time.Duration(200 * time.Millisecond)
 	PassivationDuration := time.Duration(3 * UnitOfTime)
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.
 		PropsFromProducer(func() actor.Actor { return &SmartActor{} }).
 		WithReceiverMiddleware(Use(&PassivationPlugin{Duration: PassivationDuration}))

--- a/protobuf/protoc-gen-gograin/template.go
+++ b/protobuf/protoc-gen-gograin/template.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 {{ range $service := .Services}}	
 var x{{ $service.Name }}Factory func() {{ $service.Name }}
 
-var rootContext = actor.EmptyRootContext()
+var rootContext = actor.EmptyRootContext
 
 func {{ $service.Name }}Factory(factory func() {{ $service.Name }}) {
 	x{{ $service.Name }}Factory = factory

--- a/remote/server.go
+++ b/remote/server.go
@@ -19,7 +19,7 @@ var (
 )
 
 // remote root context
-var rootContext = actor.EmptyRootContext()
+var rootContext = actor.EmptyRootContext
 
 // Start the remote server
 func Start(address string, options ...RemotingOption) {

--- a/router/consistent_hash_router_test.go
+++ b/router/consistent_hash_router_test.go
@@ -78,7 +78,7 @@ func TestConcurrency(t *testing.T) {
 		t.SkipNow()
 	}
 
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 
 	wait.Add(100 * 10000)
 	rpid := rootContext.Spawn(router.NewConsistentHashPool(100).WithProducer(func() actor.Actor { return &routerActor{} }))

--- a/router/router.go
+++ b/router/router.go
@@ -3,7 +3,7 @@ package router
 import "github.com/AsynkronIT/protoactor-go/actor"
 
 // router root context
-var rootContext = actor.EmptyRootContext()
+var rootContext = actor.EmptyRootContext
 
 // A type that satisfies router.Interface can be used as a router
 type RouterState interface {

--- a/stream/untyped.go
+++ b/stream/untyped.go
@@ -23,7 +23,7 @@ func (s *UntypedStream) Close() {
 func NewUntypedStream() *UntypedStream {
 	c := make(chan interface{})
 
-	rootContext := actor.EmptyRootContext()
+	rootContext := actor.EmptyRootContext
 	props := actor.PropsFromFunc(func(ctx actor.Context) {
 		switch msg := ctx.Message().(type) {
 		case actor.AutoReceiveMessage, actor.SystemMessage:

--- a/stream/untyped_test.go
+++ b/stream/untyped_test.go
@@ -10,7 +10,7 @@ import (
 func TestReceiveFromStream(t *testing.T) {
 	s := NewUntypedStream()
 	go func() {
-		rootContext := actor.EmptyRootContext()
+		rootContext := actor.EmptyRootContext
 		rootContext.Send(s.PID(), "hello")
 		rootContext.Send(s.PID(), "you")
 	}()


### PR DESCRIPTION
@rogeralsing 
This PR makes following changes:
1. make `EmptyMessageHeader` value public.
2. Change `EmptyRootContext` from a function to a value. Since a function confuses users that it will create a new RootContext every time it gets called, but in fact not.