### PR TITLE
rootContext var is now only defined once per Service

### DIFF
--- a/protobuf/protoc-gen-gograin/template.go
+++ b/protobuf/protoc-gen-gograin/template.go
@@ -18,10 +18,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+var rootContext = actor.EmptyRootContext
+
 {{ range $service := .Services}}	
 var x{{ $service.Name }}Factory func() {{ $service.Name }}
-
-var rootContext = actor.EmptyRootContext
 
 func {{ $service.Name }}Factory(factory func() {{ $service.Name }}) {
 	x{{ $service.Name }}Factory = factory


### PR DESCRIPTION
If you set up one or more Services in the protos.proto you'll get multiple declarations of the `rootContext` var.

Simple fix I guess :)